### PR TITLE
Fixing a missing device address for BLAS

### DIFF
--- a/src/vulkan_as_3.cpp
+++ b/src/vulkan_as_3.cpp
@@ -321,6 +321,16 @@ void build_bottom_level_acceleration_structures(const vulkan_setup_t& vulkan, Re
 		vkFreeCommandBuffers(vulkan.device, resources.command_pool, 1, &command_buffer);
 	}
 
+	// After copying the compacted acceleration structures, record their device addresses for next test stage
+	VkAccelerationStructureDeviceAddressInfoKHR blas_device_adress_info{VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR, nullptr};
+
+	for(uint32_t as_index = 0; as_index <bl_as_build_count; ++as_index)
+	{
+		blas_device_adress_info.accelerationStructure = resources.opt_bl_acc_structures[as_index].handle;
+		resources.opt_bl_acc_structures[as_index].address.deviceAddress = resources.functions.vkGetAccelerationStructureDeviceAddressKHR(vulkan.device, &blas_device_adress_info);
+		assert(resources.opt_bl_acc_structures[as_index].address.deviceAddress);
+	}
+
 	for(uint32_t as_index = 0; as_index < bl_as_build_count; ++as_index)
 	{
 		delete as_build_range_infos[as_index];

--- a/src/vulkan_as_4.cpp
+++ b/src/vulkan_as_4.cpp
@@ -203,7 +203,11 @@ void prepare_acceleration_structures(const vulkan_setup_t & vulkan, Resources & 
 	check(vkQueueSubmit(resources.queue, 1, &submitInfo, nullptr));
 	check(vkQueueWaitIdle(resources.queue));
 
-	// Build top level acceleration structure
+	// Record device adress for next test stage
+	VkAccelerationStructureDeviceAddressInfoKHR blas_device_adress_info{VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR, nullptr};
+	blas_device_adress_info.accelerationStructure = resources.blas.handle;
+	resources.blas.address.deviceAddress = resources.functions.vkGetAccelerationStructureDeviceAddressKHR(vulkan.device, &blas_device_adress_info);
+
 	vkFreeMemory(vulkan.device, scratch_bottom.memory, nullptr);
 	vkDestroyBuffer(vulkan.device, scratch_bottom.handle, nullptr);
 
@@ -213,6 +217,7 @@ void prepare_acceleration_structures(const vulkan_setup_t & vulkan, Resources & 
 			0.0f, 0.0f, 1.0f, 0.0f
 	};
 
+	// Build top level acceleration structure
 	VkAccelerationStructureInstanceKHR instance;
 	instance.transform = identity;
 	instance.instanceCustomIndex = 0;


### PR DESCRIPTION
- Fixing the zero device address for bottom level acceleration structures in two tests