### PR TITLE
Add generated __pycache__ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 reports
 traces
 external
+__pycache__


### PR DESCRIPTION
This folder is automatically generated when running python scripts and is a bit annoying (in particular when tracetooltests is used as a submodule)