### PR TITLE
Proposed changes to the Benchmarking Standard

### DIFF
--- a/doc/BenchmarkingStandard.md
+++ b/doc/BenchmarkingStandard.md
@@ -8,7 +8,7 @@ There are three target groups for this initiative:
 * People doing performance testing.  This could be end users who want to know the performance of their own system, Youtube reviewers, tech journalists, or people working for hardware vendors. Basically anyone trying to get reliable data about the performance of a particular piece of content.
 * People trying to debug some application issue. This could be end users or vendors, typically trying to go through options systematically to try to narrow down what it is that is causing whatever issue they are seeing.
 
-We hope that applications by adopting parts of this standard can improve the software ecosystem as a whole by making it easier to conduct automated testing and quality reviews.
+We hope that applications, by adopting parts of this standard, can improve the software ecosystem as a whole by making it easier to conduct automated testing and quality reviews.
 
 This standard describes three things:
 
@@ -22,61 +22,71 @@ The minimum standards implementation is to provide a JSON capabilities file with
 
 ## Capabilities file
 
+### Description
+
 The capabilities file is a JSON that the application bundles to describe which standard features it is offering and how it can be used.
 
-### Specification
-
-Platform independent JSON description of this form:
+Here's an example of capabilities JSON file:
 
 ```json
     {
-        "name": "app name",
-        "description": "free form optional description of the app",
+        "name": "application.name",
+        "description": "Optional description of the application",
+        "std_version": 1,
         "scenes": {
-            "example": {
-                "description": "free form human readable description of the scene"
+            "scene_1_name": {
+                "description": "Human readable description of scene 1"
+            },
+            "scene_2_name": {
+                "description": "Human readable description of scene 2"
             }
         },
         "settings": {
-            "example": {
-                "description": "free form human readable description of the option",
+            "setting_1_name": {
+                "description": "Human readable description of setting 1",
                 "type": "selection",
                 "options": [ "high performance", "balanced", "high quality" ]
+            },
+            "setting_2_name": {
+                "description": "Human readable description of setting 2",
+                "type": "bool"
+            },
+            "setting_3_name": {
+                "description": "Human readable description of setting 3",
+                "type": "number",
+                "min": 0,
+                "max": 3.14
             }
         },
         "capabilities": {
-            "non_interactive": "always"
+            "non_interactive": {
+                "default": true,
+                "modifiable": false
+            },
+            "fixed_framerate": {
+                "default": 0,
+                "modifiable": true
+            }
         },
         "adaptations": {
-            "example": "free form human readable description of the adaptation"
+            "adaptation_1_name": "Human readable description of adaptation 1",
+            "adaptation_2_name": "Human readable description of adaptation 2"
         }
     }
 ```
 
-An actual example from this repository:
+### Specification
 
-```json
-{
-	"name": "gles_bindbufferrange_1",
-	"description": "Test of glBindBufferRange",
-	"capabilities": {
-		"non_interactive": "always",
-		"fixed_framerate": "always",
-		"loops": "option",
-		"gpu_frame_deterministic": "always",
-		"gpu_fully_deterministic": "always"
-	}
-}
-```
+#### Top-level fields
 
-The defined top-level fields are as follows:
+Available fields that can be added at the root of the JSON capabilities file:
 
 | Field | Mandatory | Description |
 | ----- | --------- | ----------- |
 | name | Yes | Name of the application described |
 | path | Maybe | Path to the executable. Required if the executable is not in the same directory as the capability file or does not have the same name as the ```name``` field. If the path is not absolute, it is relative to the directory of the capability file. |
 | description | No | A short human readable description of the content |
-| std_version | No | Version of this standard that is supported. The default value is 1. |
+| std_version | No | Version of this standard that is supported. The default value is 1 |
 | scenes | No | Dictionary describing the scenes found in the content and that can be activated. |
 | settings | No | Dictionary describing application-defined settings that are available. |
 | capabilities | No | Dictionary describing standard-defined capabilities that are available. |
@@ -98,44 +108,47 @@ Available fields that can be added in each settings entry:
 | Field | Mandatory | Description |
 | ----- | --------- | ----------- |
 | description | Yes | A short human readable description of the option |
-| type | Yes | One of "selection", "bool", or "number" |
-| options | If "selection" in type | If type is "selection", this must be an array of possible values for the setting |
-| min | If "number" in type | If type is "number", this must be the minimum value for this setting |
-| max | If "number" in type | If type is "number", this must be the maximum value for this setting |
+| type | Yes | One of `selection`, `bool`, or `number` |
+| options | If type is `selection` | If type is `selection`, this must be an array of possible values for the setting |
+| min | If type is `number` | If type is `number`, this must be the minimum value for this setting |
+| max | If type is `number` | If type is `number`, this must be the maximum value for this setting |
 
 #### Capabilities
 
-The capabilities entry is a list of key-value pairs, where the key is one of those described in the table below, and the value is a setting enum type as described below. In the enable file it takes a value as described in the table below.
+The capabilities entry is a list of key-value pairs, where the key is the name of a capability supported by the application as described in the table below, and the value is an entry describing the properties of the capability for this application.
 
-| Capability | Enable value type | Enable values allowed | Description |
-| ---------- | ----------------- | --------------------- | ------------|
-| non_interactive | bool | true | The application is capable to run in fully non-interactive mode. If enabled, it must automatically run the activated scenes (or some default scene if none given or scene selection not supported), and then if able to run it to completion, exit with a successful exit code. If it fails to complete the scene, it shall exit with a failure exit code. |
-| fixed_framerate | number | zero or higher | The application is capable of running in a fixed framerate mode. This means that no matter the performance it will render the same content in the same number of frames every time. If the enable value is set to a non-zero value, this is the number of desired milliseconds of simulated rendering time between each frame. If zero, an application provided default frame time shall be used. |
-| no_cpu_performance_adaptations | bool | true | The application is capable of disabling dynamic runtime CPU adaptations to improve performance. This also include using settings that are adapted to application prior knowledge of the device performance and core pinning, but not sizing thread pools according to CPU core numbers. |
-| no_gpu_performance_adaptations | bool | true | The application is capable of disabling dynamic runtime graphics adaptations to improve performance. This also include using settings that are adapted to application prior knowledge of the device performance. |
-| no_vendor_performance_adaptations | bool | true | The application is capable of disabling vendor specific adaptations to improve performance. If specific adaptations are exposed in the capabilities file and are enabled in the enable file, those adaptations should override changes made by this option. |
-| no_vendor_workarounds	| bool | true | The application is capable of disabling vendor specific bug workarounds that have been added to prevent rendering artifacts or crashes. If specific adaptations are exposed in the capabilities file and are enabled in the enable file, those adaptations should override changes made by this option. |
-| no_os_workarounds | bool | true | As above, but for workarounds that have been added to prevent rendering artifacts or crashes on specific versions of an operating or windowing system version system. |
-| no_loading_screen | bool | true | The application is capable of turning off any loading screen that is shown while the application is starting up or changing scenes. Instead, no new frames should be rendered. |
-| visual_settings | number | one or higher | The application is capable of tuning its rendering quality by giving it a 1-100 value, where 1 is lowest and 100 is highest. If present in capabilities file, must be "option" or "never". |
-| loops | number | zero or higher | The application is capable of running its scenes in a loop with no or only a minimal scene loading between each loop iteration. The enable value gives the number of loops to be run, where zero means run in an infinite loop. This is useful in particular for measuring sustained performance, or measuring power, battery and temperature. If multiple scenes are activated, the order in which they loop is up to the application. If present in capabilities file, must be "option" or "never". |
-| loop_time | number | zero or higher | The application is capable of running its scenes in a loop as above but for a certain amount of time. If present in the enable file, this gives the number of seconds to run the loop for. |
-| gpu_delay_reuse | number | one or higher | The application is capable of delaying the reuse of GPU resources. The enable value gives the number of frames that resources must not be reused for. |
-| gpu_no_coherent | bool | true | The application is capable of behaving as if no coherent memory exists, and must explicitly call the graphics API to flush any modified memory before it is to be used for rendering. This allows for instance gfxreconstruct to run in 'assisted' tracing mode instead of using guard pages which may speed up runtime performance while tracing or avoid issues with guard pages. |
-| gpu_frame_deterministic | true | true | Whether the application generates a deterministic final rendering output. |
-| gpu_fully_deterministic | true | true | Whether the application generates deterministic rendering outputs from every GPU compute or rendering step. |
-| frameless | true | true | Whether the application does not present graphical frames. If opt-out and frameless is disabled in the enable file, then it must add present or frame boundary calls. |
-| file_output | true | true | Whether the application is capable of or will generate outputs for each scene as files in the filesystem. |
+| Capability | Type | Allowed values | Description |
+| ---------- | ---- | -------------- | ----------- |
+| disable_cpu_performance_adaptations | bool | {true, false} | The application is capable of disabling dynamic runtime CPU adaptations to improve performance. This also include using settings that are adapted to application prior knowledge of the device performance and core pinning, but not sizing thread pools according to CPU core numbers. |
+| disable_gpu_performance_adaptations | bool | {true, false} | The application is capable of disabling dynamic runtime graphics adaptations to improve performance. This also include using settings that are adapted to application prior knowledge of the device performance. |
+| disable_vendor_performance_adaptations | bool | {true, false} | The application is capable of disabling vendor specific adaptations to improve performance. If specific adaptations are exposed in the capabilities file and are enabled in the enable file, those adaptations should override changes made by this option. |
+| disable_vendor_adaptations | bool | {true, false} | The application is capable of disabling vendor specific bug adaptations that have been added to prevent rendering artifacts or crashes. If specific adaptations are exposed in the capabilities file and are enabled in the enable file, those adaptations should override changes made by this option. |
+| disable_os_adaptations | bool | {true, false} | As above, but for adaptations that have been added to prevent rendering artifacts or crashes on specific versions of an operating or windowing system version system. |
+| disable_loading_screen | bool | {true, false} | The application is capable of turning off any loading screen that is shown while the application is starting up or changing scenes. Instead, no new frames should be rendered. |
+| non_interactive | bool | {true, false} | The application is capable of running in fully non-interactive mode. If enabled, it must automatically run the activated scenes (or some default scene if none given or scene selection not supported), and then if able to run it to completion, exit with a successful exit code. If it fails to complete the scene, it shall exit with a failure exit code. |
+| fixed_framerate | number | [0, inf] | The application is capable of running in a fixed framerate mode. This means that no matter the performance it will render the same content in the same number of frames every time. If the enable value is set to a non-zero value, this is the number of desired milliseconds of simulated rendering time between each frame. If zero, an application provided default frame time shall be used. |
+| visual_settings | number | [1, 100] | The application is capable of tuning its rendering quality by giving it a 1-100 value, where 1 is lowest and 100 is highest. |
+| loops | number | [0, inf] | The application is capable of running its scenes in a loop with no or only a minimal scene loading between each loop iteration. The enable value gives the number of loops to be run, where `0` means run in an infinite loop. This is useful in particular for measuring sustained performance, or measuring power, battery and temperature. If multiple scenes are activated, the order in which they loop is up to the application. If present in capabilities file, must be "option" or "never". |
+| loop_time | number | [0, inf] | The application is capable of running its scenes in a loop as above but for a certain amount of time. If present in the enable file, this gives the number of seconds to run the loop for. |
+| gpu_delay_reuse | number | [1, inf] | The application is capable of delaying the reuse of GPU resources. The enable value gives the number of frames that resources must not be reused for. |
+| gpu_no_coherent | bool | {true, false} | The application is capable of behaving as if no coherent memory exists, and must explicitly call the graphics API to flush any modified memory before it is to be used for rendering. This allows for instance gfxreconstruct to run in 'assisted' tracing mode instead of using guard pages which may speed up runtime performance while tracing or avoid issues with guard pages. |
+| gpu_frame_deterministic | bool | {true, false} | Whether the application generates a deterministic final rendering output. |
+| gpu_fully_deterministic | bool | {true, false} | Whether the application generates deterministic rendering outputs from every GPU compute or rendering step. |
+| frameless | bool | {true, false} | Whether the application does not present graphical frames. If opt-out and frameless is disabled in the enable file, then it must add present or frame boundary calls. |
+| file_output | bool | {true, false} | Whether the application is capable of or will generate outputs for each scene as files in the filesystem. |
 
-### Adaptations
+Fields that can be added in each capability properties entry:
+
+| Field | Mandatory | Description |
+| ----- | --------- | ----------- |
+| default | Yes | Default value of the capability if not set in the enable file |
+| modifiable | Yes | Boolean value indicating if the capability value can be set in the enable file or not |
+
+#### Adaptations
 
 The adaptations entry is a list of key-value pairs, where the key is an application-defined name, and the value is a free-form description of what it does.
 
 An adaptation is a behaviour that may be enabled by the application depending on runtime heuristics. The user may use the enable file to force this adaptation on or off, bypassing the runtime heuristics.
-
-### Setting enum type
-
-The setting enum type is a string with one of the values "always", "option", "opt-out", or "never". "Never" and "always" are informational, while "option" and "opt-out" means the default is on (optional) or off (opt-out) but can be changed.
 
 ## File locations
 
@@ -160,6 +173,10 @@ Otherwise, it shall be placed in the application directory and a symlink to it s
 ${HOME}/.local/share/benchmarking/
 ```
 
+### Android
+
+TBD: The only place I see would be in the application data folder `/sdcard/Android/data/{com.package.name}/`
+
 ## Benchmark mode activation
 
 Platform-specific manner in which the benchmarking mode is activated and a path to the JSON which tells the application how the user wants to use the benchmarking mode is given.
@@ -172,7 +189,7 @@ Setting both BENCHMARKING_ENABLE_PATH and BENCHMARKING_ENABLE_JSON should be con
 
 ### Android
 
-TBD
+TBD: Same as linux in an Android fashion: `setprop benchmarking.enable.path`
 
 ## Enable file
 
@@ -180,22 +197,24 @@ The enable file is a JSON where the user describes how the benchmarking mode sho
 
 See the capabilities file description above for more information on possible values for fields that reference fields in the capabilities file.
 
-Example:
+Here's an example of enable file associated with the example of capabilities file above:
 
 ```json
     {
-        "target": "<name of app>",
-        "scenes": [ "example" ],
+        "target": "application.name",
+        "scenes": [ "scene_1_name", "scene_2_name" ],
         "results": "path/to/results/file",
         "intent": "showcase",
         "settings": {
-            "example": "balanced"
+            "setting_1_name": "balanced",
+            "setting_2_name": false,
+            "setting_3_name": 1.618
         },
         "capabilities": {
-            "example": true
+            "fixed_framerate": 60
         },
-        "workarounds": {
-            "example": false
+        "adaptations": {
+            "adaptation_1_name": true
         }
     }
 ```
@@ -204,108 +223,129 @@ Description of the fields:
 
 | Field | Mandatory | Description |
 | ----- | --------- | ----------- |
-| target | Yes | Must be the same string as the "name" field of the capabilities file. Use this to ensure that we are not acting on an enable activation meant for another application by accident. If the target does not match our name, no action described in the enable file shall be carried out, including not writing anything to the results file. |
+| target | Yes | Must be the same string as the `name` field of the capabilities file. Use this to ensure that we are not acting on an enable activation meant for another application by accident. If the target does not match our name, no action described in the enable file shall be carried out, including not writing anything to the results file. |
 | scenes | No | List of scenes to activate and play |
-| intent | No | Can be one of "showcase", "benchmark" and "testing". This may be used to set reasonable defaults for other values or application configurations. |
-| results | No | Put any application specific results into this JSON file. It is described below. File should not exist on initiation of the run, and should be overwritten on success if it does |
+| intent | No | Can be one of `showcase`, `benchmark` and `testing`. This may be used to set reasonable defaults for other values or application configurations. |
+| results | No | Put any application specific results into this JSON file. Results files are described below. File should not exist on initiation of the run, and should be overwritten on success if it does. |
 | settings | No | As described above, settings that the application offers for modification and its new value. |
 | capabilities | No | As described above, capabilities that the application offers and its new value. |
-| workarounds | No | As described above, workarounds that the application allows the user to turn on or off and its new value. |
+| adaptations | No | As described above, adaptations that the application allows the user to turn on or off and its new value. |
 
 ## Results file JSON
 
 Definition of a JSON format for application output, if any. Few mandatory fields, mostly just de-conflicting. The structure is based on existing results JSON files created by Kishonti benchmarks, and patrace, gfxreconstruct (?) and vktrace tools.
 
-Example JSON:
+Here's an example of a results file associated with example of capabilities file and enable file above:
 
 ```json
     {
-        "workarounds": {
-            "example": false
-        },
-        "app_version": "application version",
+        "app_version": "x.x.x-x",
         "std_version": 1,
-        "date": "ISO date string",
+        "date": "1960-04-19",
+        "enable_file": {
+            ...
+        },
         "surface_width": 1280,
         "surface_height": 780,
-        "enable_file": { "target": "my_app" },
-        "rendering_backend": "Vulkan",
+        "rendering_backend": "vulkan",
+        "start_time": 1157369,
+        "stop_time": 1167819,
+        "adaptations": {
+            "adaptation_1_name": true,
+            "adaptation_2_name": true,
+        },
+        "platform_info": {
+            ...
+        },
+        "run_info": {
+            ...
+        },
         "results": [
             {
-                "fps": 100,
-                "start_frame": 60,
-                "end_frame": 6000,
-                "start_time": 100023,
-                "stop_time": 324000,
-                "scene": "my_scene_2000"
+                "scene": "scene_1_name",
+                "duration": 1566,
+                "frames": 94,
+                "start_time": 1157836,
+                "stop_time": 1159402,
+                "output": "path/to/render_output",
+                "output_type": "png"
+            },
+            {
+                "scene": "scene_2_name",
+                "duration": 2933,
+                "start_time": 1163152,
+                "stop_time": 1166085,
+                "output": "path/to/compute_output",
+                "output_type": "csv",
+                "validated": true
             }
         ]
     }
 ```
 
-Each field type:
+Description of the top-level fields
 
 | Field | Mandatory | Description |
 | ----- | --------- | ----------- |
-| workarounds | If 'workarounds' in capabilities | List of workarounds as defined in the capabilities file with their current value when the run was made |
 | app_version | Yes | String describing the current application version |
 | std_version | Yes | Integer describing the current version of the standard supported by the application writing the results file |
 | date | No | The current date in ISO format |
+| enable_file | Yes | Verbatim copy of the provided enable file |
 | surface_width | No ||
 | surface_height | No ||
-| enable_file | Yes | Verbatim copy of the provided enable file |
+| rendering_backend | No | If the application has multiple rendering backends, specify which one in this free form text field. |
+| start_time | If stop_time provided | The time in milliseconds since the system-defined Epoch that the application started initializing. |
+| stop_time | No | The time in milliseconds since Epoch that the application started terminating. |
+| adaptations | If 'adaptations' in capabilities | List of adaptations as defined in the capabilities file with their current value when the run was made |
 | platform_info | No | A free-form JSON dictionary where the application can put any information describing the current platform |
 | run_info | No | A free-form JSON dictionary where the application can put any information describing the current run |
 | results | On success | A list of dictionaries with results. If the scene has multiple scenes or is looped, it shall contain multiple entries, one for each iteration of a scene. See field descriptions below. Shall not be present on error. |
 | error	| On error | If the run failed, its value should be a free form string explaining the error. Shall not be present on success. |
-| init_time | If end_time provided | The time in milliseconds since the system-defined Epoch that the application started initializing. |
-| end_time | No | The time in milliseconds since Epoch that the application started terminating. |
-| rendering_backend | No | If the application has multiple rendering backends, specify which one in this free form text field. |
 
 Results fields:
 
 | Field | Mandatory | Description |
 | ----- | --------- | ----------- |
-| frames | No | Frames generated while running the scene (if applicable) |
-| time | Yes | Wall clock duration of the scene in milliseconds |
+| duration | Yes | Wall clock duration of the scene in milliseconds |
 | scene | No | If there are different scenes, can specify the name of which one was run |
-| start_marker | No | If the start point of the scene in the API command stream is marked, give name of the marker. For Vulkan, this shall be using VK_EXT_debug_utils. For GL(ES), this shall be using GL_EXT_debug_marker. |
-| stop_marker | No | As above, but for the stop point of the scene. |
+| frames | No | Number of frames generated while running the scene (if applicable) |
+| start_marker | No | Name of the marker if the start point of the scene in the API command stream is marked. For Vulkan, this shall be using VK_EXT_debug_utils. For GL(ES), this shall be using GL_EXT_debug_marker. |
+| stop_marker | No | Same as `start_marker`, but for the stop point of the scene. |
 | start_time | No | The time in milliseconds since Epoch that the scene started. |
-| stop_time | No | As above, but when scene ended. If present, ```start_time``` must also be present, and (```stop_time``` - ```start_time```) must be equal to ```time```. |
+| stop_time | No | As above, but when scene ended. If present, `start_time` must also be present, and (`stop_time - start_time`) must be equal to `time`. |
 | output | No | If the scene generates output as a file, in which case this field gives the filename of this file. |
-| output_type | No | If the scene generates output as a file, this field can give the type of output. It can be one of 'png', 'jpeg' or 'csv'. The deterministic capability values apply to this output. |
-| validated | If frameless | True if the application has validated its own output to verify that it works correctly. This is usually only applicable to compute content. |
+| output_type | No | If the scene generates output as a file, this field can give the type of output. It can be one of `png`, `jpeg` or `csv`. The deterministic capability values apply to this output. |
+| validated | If frameless | `true` if the application has validated its own output to verify that it works correctly. This is usually only applicable to compute content. |
 
 ## CMake integration
 
 This is a way to do basic integration into a cmake setup:
-* Add a directory ```benchmarking``` that contains .bench enable files.
-* In CMakeLists.txt add a ```file(COPY ${PROJECT_SOURCE_DIR}/benchmarking/${ARGV0}.bench DESTINATION ${CMAKE_CURRENT_BINARY_DIR})``` for each relevant executable target where ${ARGV0} is the executable name
-* As above, also add ```install(FILES ${PROJECT_SOURCE_DIR}/benchmarking/${ARGV0}.bench DESTINATION bin)``` in CMakeLists.txt for each executable target, assuming the target also installs into ```bin```
+* Add a directory `benchmarking` that contains .bench enable files.
+* In CMakeLists.txt add a `file(COPY ${PROJECT_SOURCE_DIR}/benchmarking/${ARGV0}.bench DESTINATION ${CMAKE_CURRENT_BINARY_DIR})` for each relevant executable target where `${ARGV0}` is the executable name
+* As above, also add `install(FILES ${PROJECT_SOURCE_DIR}/benchmarking/${ARGV0}.bench DESTINATION bin)` in CMakeLists.txt for each executable target, assuming the target also installs into `bin`
 
 In order to add capability file symlinks during installation, also add:
-```
+```cmake
 set(SYMLINK_DIR "$ENV{HOME}/.local/share/benchmarking")
 install(DIRECTORY DESTINATION "${SYMLINK_DIR}")
 ```
+
 very early in the CMakeLists.txt and then for each executable target add:
-```
+```cmake
 install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/bin/${ARGV0}.bench ${SYMLINK_DIR}/${ARGV0}.bench)")
 ```
 
 If you want to enable automated testing with this standard into your CTest suite, you can do it in this way:
-
-```
+```cmake
 set(ENABLE_JSON "{\"target\": \"${ARGV0}\"}")
 set_tests_properties(${ARGV0} ENVIRONMENT "BENCHMARKING_ENABLE_JSON=${ENABLE_JSON}")
 ```
 
 ## Examples
 
-If you want to run an application in benchmarking mode on Linux, the simplest way is to use BENCHMARKING_ENABLE_JSON in this manner:
+If you want to run an application in benchmarking mode on Linux, the simplest way is to use `BENCHMARKING_ENABLE_JSON` in this manner:
 
-```
+```shell
 BENCHMARKING_ENABLE_JSON="{\"target\":\"vulkan_thread_1\"}" ./vulkan_thread_1
 ```
 


### PR DESCRIPTION
Hello ! So here are some changes I think could be good for the Benchmarking standard.

I mainly changed the examples to be more useful and easy to understand: Basically I create a fake capabilities file, an enable file for this fake capabilities file, and a result file that could be the output of this capabilities and enable file. It's more easy to understand for the reader if the examples are related to each other.

I also changed some field:
- "disable" instead of "no": I think it's more clear to say that the application "has the capability to disable..." than "has the capability to not.."
- Change the std_version to a string.

The commit is not finished, as there seem to be big differences between the "results fields" and the example given as results, so we need to talk about it, I also haven't reviewed the CMake integration yet.

Also, I am not sure to understand what the "path" field in the capabilities file is in the context of an Android application.