### PR TITLE
fix the failure of graphics_1 tracing

### DIFF
--- a/src/vulkan_common.cpp
+++ b/src/vulkan_common.cpp
@@ -43,9 +43,12 @@ void test_done(vulkan_setup_t& vulkan, bool shared_instance)
 {
 	bench_done(vulkan.bench);
 	vkDestroyDevice(vulkan.device, nullptr);
+	vulkan.device = VK_NULL_HANDLE;
+
 	if (!shared_instance)
 	{
 		vkDestroyInstance(vulkan.instance, nullptr);
+		vulkan.instance = VK_NULL_HANDLE;
 	}
 }
 

--- a/src/vulkan_graphics_common.cpp
+++ b/src/vulkan_graphics_common.cpp
@@ -1487,8 +1487,9 @@ VkResult BasicContext::initBasic(vulkan_setup_t& vulkan, vulkan_req_t& reqs)
 	if (!reqs.options.count("height")) reqs.options["height"] = 480;
 	if (!reqs.options.count("wg_size")) reqs.options["wg_size"] = 32;
 
-	const uint32_t width = std::get<int>(reqs.options.at("width"));
-	const uint32_t height = std::get<int>(reqs.options.at("height"));
+	width = static_cast<uint32_t>(std::get<int>(reqs.options.at("width")));
+	height = static_cast<uint32_t>(std::get<int>(reqs.options.at("height")));
+	wg_size = static_cast<uint32_t>(std::get<int>(reqs.options.at("wg_size")));
 
 	m_defaultCommandPool = std::make_shared<CommandBufferPool>(vulkan.device);
 	m_frameBoundaryCommandBuffer = std::make_shared<CommandBuffer>(m_defaultCommandPool);

--- a/src/vulkan_graphics_common.h
+++ b/src/vulkan_graphics_common.h
@@ -479,9 +479,15 @@ public:
 
 	~AttachmentInfo()
 	{
-		DLOG3("MEM detection: attacmentInfo destructor().");
+		destroy();
+	}
+
+	VkResult destroy()
+	{
+		DLOG3("MEM detection: attacmentInfo destroy().");
 		resetDescription();
 		m_pImageView = nullptr;
+		return VK_SUCCESS;
 	}
 
 private:
@@ -722,6 +728,10 @@ class BasicContext
 public:
 	BasicContext() { }
 	VkResult initBasic(vulkan_setup_t& vulkan, vulkan_req_t& reqs);
+
+	uint32_t width;
+	uint32_t height;
+	uint32_t wg_size;
 
 	std::shared_ptr<CommandBufferPool> m_defaultCommandPool;
 	std::shared_ptr<CommandBuffer> m_defaultCommandBuffer;


### PR DESCRIPTION
1. Change the global benchmark object to benchmark pointer. 
Using benchmark object, destructor can be invoking after the main app exiting. 
While it runs out of the main process and gfxr capture_manager is destroyed.

2. Set local shared_ptr pointer to null; Explicitly call destroy() on local object. 
It is to release reference on shared_ptr.

3. Small improvements.