### PR TITLE
Change image format in compute resources

### DIFF
--- a/src/vulkan_compute_common.cpp
+++ b/src/vulkan_compute_common.cpp
@@ -112,7 +112,7 @@ compute_resources compute_init(vulkan_setup_t& vulkan, vulkan_req_t& reqs)
 	VkImageCreateInfo imageCreateInfo = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, nullptr };
 	imageCreateInfo.flags = 0;
 	imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
-	imageCreateInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
+	imageCreateInfo.format = VK_FORMAT_R32G32B32A32_SFLOAT;
 	imageCreateInfo.extent.width = width;
 	imageCreateInfo.extent.height = height;
 	imageCreateInfo.extent.depth = 1;


### PR DESCRIPTION
Compute shaders often output a vec4, which translates to `VK_FORMAT_R32G32B32A32_SFLOAT` instead of `VK_FORMAT_R8G8B8A8_UNORM`