### PR TITLE
refine vulkan_graphics_common shared ownership and descriptor/render …

### DIFF
--- a/src/vulkan_address_remap_test_1.cpp
+++ b/src/vulkan_address_remap_test_1.cpp
@@ -124,31 +124,30 @@ int main(int argc, char** argv)
 	set_layout->insertBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_SHADER_STAGE_COMPUTE_BIT);
 	set_layout->create();
 
-	auto set_pool = std::make_shared<DescriptorSetPool>(set_layout);
-	set_pool->create(1);
+	auto set_pool = std::make_shared<DescriptorSetPool>(vulkan.device);
+	set_pool->create(1, {{VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1}});
 
 	auto descriptor_set = std::make_shared<DescriptorSet>(set_pool);
-	descriptor_set->create();
-	descriptor_set->setBuffer(0, offsets_buffer);
+	descriptor_set->create(*set_layout);
+	descriptor_set->setBuffer(0, 0, offsets_buffer);
 	descriptor_set->update();
 
-	std::unordered_map<uint32_t, std::shared_ptr<DescriptorSetLayout>> layout_map = {{0, set_layout}};
+	std::vector<VkDescriptorSetLayout> set_layouts = { set_layout->getHandle() };
 	VkPushConstantRange push_range{};
 	push_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
 	push_range.offset = 0;
 	push_range.size = sizeof(PushConstants);
 
 	auto pipeline_layout = std::make_shared<PipelineLayout>(vulkan.device);
-	pipeline_layout->create(layout_map, {push_range});
+	pipeline_layout->create(set_layouts, {push_range});
 
 	auto shader = std::make_shared<Shader>(vulkan.device);
 	shader->create(vulkan_address_remap_test_1_spirv, vulkan_address_remap_test_1_spirv_len);
 	ShaderPipelineState shader_stage(VK_SHADER_STAGE_COMPUTE_BIT, shader);
 
-	auto pipeline = std::make_shared<ComputePipeline>(pipeline_layout);
-	pipeline->create(shader_stage);
+	auto pipeline = std::make_shared<ComputePipeline>(vulkan.device);
+	pipeline->create(pipeline_layout->getHandle(), shader_stage);
 	shader_stage.destroy();
-	shader_stage.m_pShader.reset();
 
 	auto command_pool = std::make_shared<CommandBufferPool>(vulkan.device);
 	command_pool->create(VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT, 0);
@@ -224,7 +223,6 @@ int main(int argc, char** argv)
 	set_pool.reset();
 	pipeline.reset();
 	shader.reset();
-	layout_map.clear(); // drop shared_ptr ref before destroying device
 	pipeline_layout.reset();
 	set_layout.reset();
 	command_buffer.reset();

--- a/src/vulkan_compute_bda_copying_address.cpp
+++ b/src/vulkan_compute_bda_copying_address.cpp
@@ -102,6 +102,7 @@ public:
 		m_initPipeline = nullptr;
 		m_interleavePipeline = nullptr;
 		m_outputPipeline = nullptr;
+		m_computePipelineLayout = nullptr;
 
 		if (m_frameFence != VK_NULL_HANDLE)
 		{
@@ -120,6 +121,7 @@ public:
 	std::unique_ptr<ComputePipeline> m_initPipeline;
 	std::unique_ptr<ComputePipeline> m_interleavePipeline;
 	std::unique_ptr<ComputePipeline> m_outputPipeline;
+	std::shared_ptr<PipelineLayout> m_computePipelineLayout;
 
 	VkFence m_frameFence = VK_NULL_HANDLE;
 	uint32_t numPixelsPerBuffer;
@@ -166,6 +168,7 @@ int main(int argc, char** argv)
 	std::vector<VkPushConstantRange> range = { {VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pushAddress)} };
 	auto pipeline_layout = std::make_shared<PipelineLayout>(vulkan.device);
 	pipeline_layout->create(range);
+	p_benchmark->m_computePipelineLayout = pipeline_layout;
 
 	/******************* shader and pipeline *********************/
 	std::vector<VkSpecializationMapEntry> smentries(6);
@@ -192,8 +195,8 @@ int main(int argc, char** argv)
 		ShaderPipelineState initShaderStage(VK_SHADER_STAGE_COMPUTE_BIT, std::move(initShader));
 		initShaderStage.setSpecialization(smentries, 4 * sdata.size(), sdata.data());
 
-		p_benchmark->m_initPipeline = std::make_unique<ComputePipeline>(pipeline_layout);
-		p_benchmark->m_initPipeline->create(initShaderStage);
+		p_benchmark->m_initPipeline = std::make_unique<ComputePipeline>(vulkan.device);
+		p_benchmark->m_initPipeline->create(pipeline_layout->getHandle(), initShaderStage);
 
 		initShaderStage.destroy();
 	}
@@ -210,11 +213,11 @@ int main(int argc, char** argv)
 	ShaderPipelineState outputShaderStage(VK_SHADER_STAGE_COMPUTE_BIT, std::move(outputShader));
 	outputShaderStage.setSpecialization(smentries, 4 * sdata.size(), sdata.data());
 
-	p_benchmark->m_interleavePipeline = std::make_unique<ComputePipeline>(pipeline_layout);
-	p_benchmark->m_interleavePipeline->create(interleaveShaderStage);
+	p_benchmark->m_interleavePipeline = std::make_unique<ComputePipeline>(vulkan.device);
+	p_benchmark->m_interleavePipeline->create(pipeline_layout->getHandle(), interleaveShaderStage);
 
-	p_benchmark->m_outputPipeline = std::make_unique<ComputePipeline>(pipeline_layout);
-	p_benchmark->m_outputPipeline->create(outputShaderStage);
+	p_benchmark->m_outputPipeline = std::make_unique<ComputePipeline>(vulkan.device);
+	p_benchmark->m_outputPipeline->create(pipeline_layout->getHandle(), outputShaderStage);
 
 	outputShaderStage.destroy();
 	interleaveShaderStage.destroy();
@@ -310,11 +313,11 @@ static void populate_addressAndColorBuffer(uint32_t numPixelsPerBuffer)
 		frf.pNext = &markings;
 
 		range.memory = p_benchmark->m_colorBuffer->getMemory();
-		VkResult result = vkFlushMappedMemoryRanges(p_benchmark->m_colorBuffer->m_device, 1, &range);
+		VkResult result = vkFlushMappedMemoryRanges(p_benchmark->m_colorBuffer->getDevice(), 1, &range);
 		check(result);
 
 		range.memory = p_benchmark->m_addressBuffer->getMemory();
-		result = vkFlushMappedMemoryRanges(p_benchmark->m_addressBuffer->m_device, 1, &range);
+		result = vkFlushMappedMemoryRanges(p_benchmark->m_addressBuffer->getDevice(), 1, &range);
 		check(result);
 	}
 
@@ -331,7 +334,7 @@ static void populate_addressAndColorBuffer_comp(VkCommandBuffer commandBuffer, u
 	push_address.BDA = p_benchmark->m_baseAddressBuffer->getBufferDeviceAddress();
 	push_address.colorBDA = p_benchmark->m_colorBuffer->getBufferDeviceAddress();
 	push_address.addressBDA = p_benchmark->m_addressBuffer->getBufferDeviceAddress();
-	push_address_constants(commandBuffer, p_benchmark->m_vulkanSetup, p_benchmark->m_initPipeline->m_pipelineLayout->getHandle(),
+	push_address_constants(commandBuffer, p_benchmark->m_vulkanSetup, p_benchmark->m_computePipelineLayout->getHandle(),
 	                       push_address, 3, sizeof(push_address));
 
 	vkCmdDispatch(commandBuffer, groupCount_x, groupCount_y, 1);
@@ -418,7 +421,7 @@ static void render(vulkan_setup_t& vulkan)
 		push_address.BDA = p_benchmark->m_interleaveBuffer->getBufferDeviceAddress();
 		push_address.colorBDA = p_benchmark->m_colorBuffer->getBufferDeviceAddress();
 		push_address.addressBDA = p_benchmark->m_addressBuffer->getBufferDeviceAddress();
-		push_address_constants(defaultCmd, p_benchmark->m_vulkanSetup, p_benchmark->m_interleavePipeline->m_pipelineLayout->getHandle(),
+		push_address_constants(defaultCmd, p_benchmark->m_vulkanSetup, p_benchmark->m_computePipelineLayout->getHandle(),
 		                       push_address, 3, sizeof(push_address));
 
 		vkCmdDispatch(defaultCmd, groupCount_x, groupCount_y, 1);
@@ -440,7 +443,7 @@ static void render(vulkan_setup_t& vulkan)
 		push_address.colorBDA = 0;
 		push_address.addressBDA = 0;
 		push_address.BDA = p_benchmark->m_interleaveBuffer->getBufferDeviceAddress();
-		push_address_constants(defaultCmd, p_benchmark->m_vulkanSetup, p_benchmark->m_outputPipeline->m_pipelineLayout->getHandle(),
+		push_address_constants(defaultCmd, p_benchmark->m_vulkanSetup, p_benchmark->m_computePipelineLayout->getHandle(),
 		                       push_address, 1, sizeof(VkDeviceAddress));
 		vkCmdDispatch(defaultCmd, groupCount_x, groupCount_y, 1);
 

--- a/src/vulkan_demo_bloom_minimal.cpp
+++ b/src/vulkan_demo_bloom_minimal.cpp
@@ -84,7 +84,7 @@ static ColorTarget create_color_target(const vulkan_setup_t& vulkan, VkExtent2D 
 	target.view = std::make_shared<ImageView>(target.image);
 	target.view->create(VK_IMAGE_VIEW_TYPE_2D, VK_IMAGE_ASPECT_COLOR_BIT);
 
-	AttachmentInfo color{0, target.view, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+	AttachmentInfo color{0, *target.view, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
 	color.m_description.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 	color.m_description.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
@@ -95,7 +95,7 @@ static ColorTarget create_color_target(const vulkan_setup_t& vulkan, VkExtent2D 
 	target.renderPass->create({color}, {subpass});
 
 	target.framebuffer = std::make_shared<FrameBuffer>(vulkan.device);
-	target.framebuffer->create(*target.renderPass, extent);
+	target.framebuffer->create(*target.renderPass, {target.view}, extent);
 
 	return target;
 }
@@ -358,13 +358,15 @@ int main(int argc, char** argv)
 	sceneDescLayout->insertBinding(1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT);
 	sceneDescLayout->create();
 
-	auto sceneDescPool = std::make_shared<DescriptorSetPool>(sceneDescLayout);
-	sceneDescPool->create(1);
+	auto sceneDescPool = std::make_shared<DescriptorSetPool>(vulkan.device);
+	sceneDescPool->create(1,
+	                      {{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1},
+	                       {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1}});
 
 	auto sceneDescriptor = std::make_unique<DescriptorSet>(sceneDescPool);
-	sceneDescriptor->create();
-	sceneDescriptor->setBuffer(0, *sceneUbo);
-	sceneDescriptor->setCombinedImageSampler(1, *dummyImageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *sampler);
+	sceneDescriptor->create(*sceneDescLayout);
+	sceneDescriptor->setBuffer(0, 0, *sceneUbo);
+	sceneDescriptor->setCombinedImageSampler(1, 0, *dummyImageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *sampler);
 	sceneDescriptor->update();
 
 	auto blurDescLayout = std::make_shared<DescriptorSetLayout>(vulkan.device);
@@ -372,27 +374,29 @@ int main(int argc, char** argv)
 	blurDescLayout->insertBinding(1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT);
 	blurDescLayout->create();
 
-	auto blurDescPool = std::make_shared<DescriptorSetPool>(blurDescLayout);
-	blurDescPool->create(2);
+	auto blurDescPool = std::make_shared<DescriptorSetPool>(vulkan.device);
+	blurDescPool->create(2,
+	                     {{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 2},
+	                      {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2}});
 
 	auto blurDescriptorH = std::make_unique<DescriptorSet>(blurDescPool);
-	blurDescriptorH->create();
-	blurDescriptorH->setBuffer(0, *blurUbo);
-	blurDescriptorH->setCombinedImageSampler(1, *p_benchmark->sceneTarget.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *sampler);
+	blurDescriptorH->create(*blurDescLayout);
+	blurDescriptorH->setBuffer(0, 0, *blurUbo);
+	blurDescriptorH->setCombinedImageSampler(1, 0, *p_benchmark->sceneTarget.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *sampler);
 	blurDescriptorH->update();
 
 	auto blurDescriptorV = std::make_unique<DescriptorSet>(blurDescPool);
-	blurDescriptorV->create();
-	blurDescriptorV->setBuffer(0, *blurUbo);
-	blurDescriptorV->setCombinedImageSampler(1, *p_benchmark->blurTargetH.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *sampler);
+	blurDescriptorV->create(*blurDescLayout);
+	blurDescriptorV->setBuffer(0, 0, *blurUbo);
+	blurDescriptorV->setCombinedImageSampler(1, 0, *p_benchmark->blurTargetH.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *sampler);
 	blurDescriptorV->update();
 
 	{
-		std::unordered_map<uint32_t, std::shared_ptr<DescriptorSetLayout>> scene_layouts = {{0, sceneDescLayout}};
+		std::vector<VkDescriptorSetLayout> scene_layouts = { sceneDescLayout->getHandle() };
 		p_benchmark->scenePipelineLayout = std::make_shared<PipelineLayout>(vulkan.device);
 		p_benchmark->scenePipelineLayout->create(scene_layouts);
 
-		std::unordered_map<uint32_t, std::shared_ptr<DescriptorSetLayout>> blur_layouts = {{0, blurDescLayout}};
+		std::vector<VkDescriptorSetLayout> blur_layouts = { blurDescLayout->getHandle() };
 		p_benchmark->blurPipelineLayout = std::make_shared<PipelineLayout>(vulkan.device);
 		p_benchmark->blurPipelineLayout->create(blur_layouts);
 	}
@@ -454,14 +458,14 @@ int main(int argc, char** argv)
 		blur_dir = 0;
 		blurFragStageV.setSpecialization(blur_entries, sizeof(blur_dir), &blur_dir);
 
-		p_benchmark->scenePipeline = std::make_unique<GraphicPipeline>(p_benchmark->scenePipelineLayout);
-		p_benchmark->scenePipeline->create({colorVertStage, colorFragStage}, sceneState, *p_benchmark->sceneTarget.renderPass);
+		p_benchmark->scenePipeline = std::make_unique<GraphicPipeline>(vulkan.device);
+		p_benchmark->scenePipeline->create(p_benchmark->scenePipelineLayout->getHandle(), {colorVertStage, colorFragStage}, sceneState, *p_benchmark->sceneTarget.renderPass);
 
-		p_benchmark->blurPipelineH = std::make_unique<GraphicPipeline>(p_benchmark->blurPipelineLayout);
-		p_benchmark->blurPipelineH->create({blurVertStage, blurFragStageH}, blurState, *p_benchmark->blurTargetH.renderPass);
+		p_benchmark->blurPipelineH = std::make_unique<GraphicPipeline>(vulkan.device);
+		p_benchmark->blurPipelineH->create(p_benchmark->blurPipelineLayout->getHandle(), {blurVertStage, blurFragStageH}, blurState, *p_benchmark->blurTargetH.renderPass);
 
-		p_benchmark->blurPipelineV = std::make_unique<GraphicPipeline>(p_benchmark->blurPipelineLayout);
-		p_benchmark->blurPipelineV->create({blurVertStage, blurFragStageV}, blurState, *p_benchmark->blurTargetV.renderPass);
+		p_benchmark->blurPipelineV = std::make_unique<GraphicPipeline>(vulkan.device);
+		p_benchmark->blurPipelineV->create(p_benchmark->blurPipelineLayout->getHandle(), {blurVertStage, blurFragStageV}, blurState, *p_benchmark->blurTargetV.renderPass);
 	}
 
 	p_benchmark->vertexBuffer = std::move(vertexBuffer);

--- a/src/vulkan_demo_descriptor_buffer_minimal.cpp
+++ b/src/vulkan_demo_descriptor_buffer_minimal.cpp
@@ -132,7 +132,7 @@ static ColorTarget create_color_target(const vulkan_setup_t& vulkan, VkExtent2D 
 	target.view = std::make_shared<ImageView>(target.image);
 	target.view->create(VK_IMAGE_VIEW_TYPE_2D, VK_IMAGE_ASPECT_COLOR_BIT);
 
-	AttachmentInfo color{0, target.view, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+	AttachmentInfo color{0, *target.view, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
 	color.m_description.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 	color.m_description.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
@@ -143,7 +143,7 @@ static ColorTarget create_color_target(const vulkan_setup_t& vulkan, VkExtent2D 
 	target.renderPass->create({color}, {subpass});
 
 	target.framebuffer = std::make_shared<FrameBuffer>(vulkan.device);
-	target.framebuffer->create(*target.renderPass, extent);
+	target.framebuffer->create(*target.renderPass, {target.view}, extent);
 
 	return target;
 }
@@ -485,13 +485,13 @@ int main(int argc, char** argv)
 	p_benchmark->imageDesc.address = p_benchmark->imageDesc.buffer->getBufferDeviceAddress();
 
 	{
-		std::unordered_map<uint32_t, std::shared_ptr<DescriptorSetLayout>> layout_map = {
-			{0, uniformLayout},
-			{1, uniformLayout},
-			{2, samplerLayout},
+		std::vector<VkDescriptorSetLayout> set_layouts = {
+			uniformLayout->getHandle(),
+			uniformLayout->getHandle(),
+			samplerLayout->getHandle(),
 		};
 		p_benchmark->pipelineLayout = std::make_shared<PipelineLayout>(vulkan.device);
-		p_benchmark->pipelineLayout->create(layout_map);
+		p_benchmark->pipelineLayout->create(set_layouts);
 	}
 
 	{
@@ -523,8 +523,8 @@ int main(int argc, char** argv)
 		ShaderPipelineState vertStage(VK_SHADER_STAGE_VERTEX_BIT, vertShader);
 		ShaderPipelineState fragStage(VK_SHADER_STAGE_FRAGMENT_BIT, fragShader);
 
-		p_benchmark->pipeline = std::make_unique<GraphicPipeline>(p_benchmark->pipelineLayout);
-		p_benchmark->pipeline->create({vertStage, fragStage}, pipelineState, *p_benchmark->colorTarget.renderPass,
+		p_benchmark->pipeline = std::make_unique<GraphicPipeline>(vulkan.device);
+		p_benchmark->pipeline->create(p_benchmark->pipelineLayout->getHandle(), {vertStage, fragStage}, pipelineState, *p_benchmark->colorTarget.renderPass,
 		                              VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
 	}
 

--- a/src/vulkan_demo_descriptor_indexing.cpp
+++ b/src/vulkan_demo_descriptor_indexing.cpp
@@ -77,7 +77,7 @@ static ColorTarget create_color_target(const vulkan_setup_t& vulkan, VkExtent2D 
 	target.view = std::make_shared<ImageView>(target.image);
 	target.view->create(VK_IMAGE_VIEW_TYPE_2D, VK_IMAGE_ASPECT_COLOR_BIT);
 
-	AttachmentInfo color{0, target.view, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+	AttachmentInfo color{0, *target.view, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
 	color.m_description.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 	color.m_description.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
@@ -88,7 +88,7 @@ static ColorTarget create_color_target(const vulkan_setup_t& vulkan, VkExtent2D 
 	target.renderPass->create({color}, {subpass});
 
 	target.framebuffer = std::make_shared<FrameBuffer>(vulkan.device);
-	target.framebuffer->create(*target.renderPass, extent);
+	target.framebuffer->create(*target.renderPass, {target.view}, extent);
 
 	return target;
 }
@@ -320,8 +320,10 @@ int main(int argc, char** argv)
 	descriptorLayout->insertNext(binding_flags_info);
 	descriptorLayout->create(static_cast<uint32_t>(descriptorLayout->getBindings().size()), 0);
 
-	auto descriptorPool = std::make_shared<DescriptorSetPool>(descriptorLayout);
-	descriptorPool->create(1);
+	auto descriptorPool = std::make_shared<DescriptorSetPool>(vulkan.device);
+	descriptorPool->create(1,
+	                       {{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1},
+	                        {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, texture_count}});
 
 	auto descriptor = std::make_unique<DescriptorSet>(descriptorPool);
 	VkDescriptorSetVariableDescriptorCountAllocateInfo var_count_info{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO_EXT, nullptr};
@@ -329,20 +331,19 @@ int main(int argc, char** argv)
 	var_count_info.descriptorSetCount = 1;
 	var_count_info.pDescriptorCounts = &variable_count;
 	descriptor->insertNext(var_count_info);
-	descriptor->create();
-	descriptor->setBuffer(0, *uniformBuffer);
-	for (auto& view : p_benchmark->textureViews)
+	descriptor->create(*descriptorLayout);
+	descriptor->setBuffer(0, 0, *uniformBuffer);
+	assert(p_benchmark->textureViews.size() == texture_count);
+	for (uint32_t i = 0; i < texture_count; ++i)
 	{
-		descriptor->setCombinedImageSampler(1, *view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *sampler);
+		descriptor->setCombinedImageSampler(1, i, *p_benchmark->textureViews[i], VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *sampler);
 	}
 	descriptor->update();
 
 	{
-		std::unordered_map<uint32_t, std::shared_ptr<DescriptorSetLayout>> layout_map = {
-			{0, descriptorLayout},
-		};
+		std::vector<VkDescriptorSetLayout> set_layouts = { descriptorLayout->getHandle() };
 		p_benchmark->pipelineLayout = std::make_shared<PipelineLayout>(vulkan.device);
-		p_benchmark->pipelineLayout->create(layout_map);
+		p_benchmark->pipelineLayout->create(set_layouts);
 	}
 
 	{
@@ -373,8 +374,8 @@ int main(int argc, char** argv)
 		ShaderPipelineState vertStage(VK_SHADER_STAGE_VERTEX_BIT, vertShader);
 		ShaderPipelineState fragStage(VK_SHADER_STAGE_FRAGMENT_BIT, fragShader);
 
-		p_benchmark->pipeline = std::make_unique<GraphicPipeline>(p_benchmark->pipelineLayout);
-		p_benchmark->pipeline->create({vertStage, fragStage}, pipelineState, *p_benchmark->colorTarget.renderPass);
+		p_benchmark->pipeline = std::make_unique<GraphicPipeline>(vulkan.device);
+		p_benchmark->pipeline->create(p_benchmark->pipelineLayout->getHandle(), {vertStage, fragStage}, pipelineState, *p_benchmark->colorTarget.renderPass);
 	}
 
 	p_benchmark->vertexBuffer = std::move(vertexBuffer);

--- a/src/vulkan_demo_graphics_pipeline_library.cpp
+++ b/src/vulkan_demo_graphics_pipeline_library.cpp
@@ -63,7 +63,7 @@ static ColorTarget create_color_target(const vulkan_setup_t& vulkan, VkExtent2D 
 	target.view = std::make_shared<ImageView>(target.image);
 	target.view->create(VK_IMAGE_VIEW_TYPE_2D, VK_IMAGE_ASPECT_COLOR_BIT);
 
-	AttachmentInfo color{0, target.view, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+	AttachmentInfo color{0, *target.view, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
 	color.m_description.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 	color.m_description.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
@@ -74,7 +74,7 @@ static ColorTarget create_color_target(const vulkan_setup_t& vulkan, VkExtent2D 
 	target.renderPass->create({color}, {subpass});
 
 	target.framebuffer = std::make_shared<FrameBuffer>(vulkan.device);
-	target.framebuffer->create(*target.renderPass, extent);
+	target.framebuffer->create(*target.renderPass, {target.view}, extent);
 
 	return target;
 }
@@ -281,20 +281,18 @@ int main(int argc, char** argv)
 	descriptorLayout->insertBinding(0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_SHADER_STAGE_VERTEX_BIT);
 	descriptorLayout->create();
 
-	auto descriptorPool = std::make_shared<DescriptorSetPool>(descriptorLayout);
-	descriptorPool->create(1);
+	auto descriptorPool = std::make_shared<DescriptorSetPool>(vulkan.device);
+	descriptorPool->create(1, {{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1}});
 
 	auto descriptor = std::make_unique<DescriptorSet>(descriptorPool);
-	descriptor->create();
-	descriptor->setBuffer(0, *uniformBuffer);
+	descriptor->create(*descriptorLayout);
+	descriptor->setBuffer(0, 0, *uniformBuffer);
 	descriptor->update();
 
 	{
-		std::unordered_map<uint32_t, std::shared_ptr<DescriptorSetLayout>> layout_map = {
-			{0, descriptorLayout},
-		};
+		std::vector<VkDescriptorSetLayout> set_layouts = { descriptorLayout->getHandle() };
 		p_benchmark->pipelineLayout = std::make_shared<PipelineLayout>(vulkan.device);
-		p_benchmark->pipelineLayout->create(layout_map);
+		p_benchmark->pipelineLayout->create(set_layouts);
 	}
 
 	{

--- a/src/vulkan_descriptor_buffer_mutable_type.cpp
+++ b/src/vulkan_descriptor_buffer_mutable_type.cpp
@@ -214,8 +214,7 @@ void setup_descriptor_set_layout()
 
 	p_benchmark->m_mutableSetLayout = std::move(mutableSetLayout);
 
-	std::unordered_map<uint32_t, std::shared_ptr<DescriptorSetLayout>>  //set num --> descriptorSetLayout
-	layoutMap = { {0, p_benchmark->m_mutableSetLayout} };
+	std::vector<VkDescriptorSetLayout> setLayouts = { p_benchmark->m_mutableSetLayout->getHandle() };
 
 	VkPushConstantRange const_range{};
 	const_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT | VK_SHADER_STAGE_VERTEX_BIT;
@@ -223,7 +222,7 @@ void setup_descriptor_set_layout()
 	const_range.size       = sizeof(CameraData);
 
 	auto pipelineLayout = std::make_unique<PipelineLayout>(p_benchmark->m_vulkanSetup.device);
-	pipelineLayout->create(layoutMap, {const_range});
+	pipelineLayout->create(setLayouts, {const_range});
 	p_benchmark->m_pipelineLayout = std::move(pipelineLayout);
 }
 
@@ -303,8 +302,8 @@ void prepare_compute_pipeline()
 
 	ShaderPipelineState cullShaderStage(VK_SHADER_STAGE_COMPUTE_BIT, std::move(cullShader));
 	cullShaderStage.setSpecialization(smentries, 4 * sdata.size(), sdata.data());
-	p_benchmark->m_cullingPipeline = std::make_unique<ComputePipeline>(p_benchmark->m_pipelineLayout);
-	p_benchmark->m_cullingPipeline->create(cullShaderStage, VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
+	p_benchmark->m_cullingPipeline = std::make_unique<ComputePipeline>(p_benchmark->m_vulkanSetup.device);
+	p_benchmark->m_cullingPipeline->create(p_benchmark->m_pipelineLayout->getHandle(), cullShaderStage, VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
 }
 
 void prepare_graphic_pipeline()
@@ -327,7 +326,7 @@ void prepare_graphic_pipeline()
 	colorImageView->create(VK_IMAGE_VIEW_TYPE_2D, VK_IMAGE_ASPECT_COLOR_BIT);
 
 	// attachments: set VkAttachmentDescription
-	AttachmentInfo color{ 0, std::move(colorImageView), VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL };
+	AttachmentInfo color{ 0, *colorImageView, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL };
 
 	// subpass: set VkAttachmentReference
 	SubpassInfo subpass{};
@@ -352,7 +351,7 @@ void prepare_graphic_pipeline()
 
 	/********************************** framebuffer *********************************/
 	auto framebuffer = std::make_unique<FrameBuffer>(p_benchmark->m_vulkanSetup.device);
-	framebuffer->create(*renderpass, {p_benchmark->width, p_benchmark->height});
+	framebuffer->create(*renderpass, {colorImageView}, {p_benchmark->width, p_benchmark->height});
 
 	/*************************** shader module **************************************/
 	auto vertShader = std::make_unique<Shader>(p_benchmark->m_vulkanSetup.device);
@@ -367,8 +366,8 @@ void prepare_graphic_pipeline()
 
 	/*************************** graphic pipeline creation **************************/
 	std::vector<ShaderPipelineState> shaderStages = {vertShaderState, fragShaderState};
-	auto pipeline = std::make_unique<GraphicPipeline>(p_benchmark->m_pipelineLayout);
-	pipeline->create(shaderStages, pipelineState, *renderpass, VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
+	auto pipeline = std::make_unique<GraphicPipeline>(p_benchmark->m_vulkanSetup.device);
+	pipeline->create(p_benchmark->m_pipelineLayout->getHandle(), shaderStages, pipelineState, *renderpass, VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
 
 	p_benchmark->m_renderPass = std::move(renderpass);
 	p_benchmark->m_framebuffer = std::move(framebuffer);

--- a/src/vulkan_graphics_1.cpp
+++ b/src/vulkan_graphics_1.cpp
@@ -91,6 +91,7 @@ public:
 		m_bgImageView = nullptr;
 		m_descriptor = nullptr;
 		m_pipeline = nullptr;
+		m_pipelineLayout = nullptr;
 
 		if (m_frameFence != VK_NULL_HANDLE)
 		{
@@ -108,6 +109,7 @@ public:
 	std::unique_ptr<ImageView> m_bgImageView;
 
 	std::unique_ptr<GraphicPipeline> m_pipeline;
+	std::shared_ptr<PipelineLayout> m_pipelineLayout;
 	std::unique_ptr<DescriptorSet> m_descriptor;
 
 	VkFence m_frameFence = VK_NULL_HANDLE;
@@ -210,27 +212,27 @@ int main(int argc, char** argv)
 
 	// descriptorPool
 #define MAX_DESCRIPTOR_SET_SIZE 4
-	auto mainDescSetPool = std::make_shared<DescriptorSetPool>(mainDescSetLayout);
-	mainDescSetPool->create(MAX_DESCRIPTOR_SET_SIZE);
+	auto mainDescSetPool = std::make_shared<DescriptorSetPool>(vulkan.device);
+	mainDescSetPool->create(MAX_DESCRIPTOR_SET_SIZE,
+	                        {{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, MAX_DESCRIPTOR_SET_SIZE},
+	                         {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, MAX_DESCRIPTOR_SET_SIZE}});
 
 	// descritorSet
 	auto descriptor = std::make_unique<DescriptorSet>(std::move(mainDescSetPool));
-	descriptor->create();
+	descriptor->create(*mainDescSetLayout);
 	//configure descriptor set, and then update
-	descriptor->setBuffer(0, *transformUniformBuffer);  //layout(set=0,binding=0) uniform transformBuffer { }
-	descriptor->setCombinedImageSampler(1, *bgImageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *bgSampler);  //layout(set=0, binding=1) uniform sampler2D
+	descriptor->setBuffer(0, 0, *transformUniformBuffer);  //layout(set=0,binding=0) uniform transformBuffer { }
+	descriptor->setCombinedImageSampler(1, 0, *bgImageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *bgSampler);  //layout(set=0, binding=1) uniform sampler2D
 	descriptor->update();
 
 
 	// ------------------------- graphic pipeline setup ------------------------------
 
 	/***************************** pipeline layout **********************************/
-	std::unordered_map<uint32_t, std::shared_ptr<DescriptorSetLayout>>  //set num --> descriptorSetLayout
-	layoutMap = { {0, mainDescSetLayout} };
+	std::vector<VkDescriptorSetLayout> setLayouts = { mainDescSetLayout->getHandle() };
 
 	auto pipelineLayout = std::make_shared<PipelineLayout>(vulkan.device);
-	pipelineLayout->create(layoutMap);
-	layoutMap[0] = nullptr;  // set local variable of shared_ptr to null
+	pipelineLayout->create(setLayouts);
 
 
 	/*************************** graphicPipeline state*******************************/
@@ -261,8 +263,8 @@ int main(int argc, char** argv)
 	depthImageView->create(VK_IMAGE_VIEW_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT);
 
 	// attachments: set VkAttachmentDescription
-	AttachmentInfo color{ 0, std::move(colorImageView), VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL };
-	AttachmentInfo depth{ 1, std::move(depthImageView), VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL };
+	AttachmentInfo color{ 0, *colorImageView, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL };
+	AttachmentInfo depth{ 1, *depthImageView, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL };
 
 	// subpass: set VkAttachmentReference
 	SubpassInfo subpass{};
@@ -289,15 +291,15 @@ int main(int argc, char** argv)
 
 	/********************************** framebuffer *********************************/
 	auto framebuffer = std::make_shared<FrameBuffer>(vulkan.device);
-	framebuffer->create(*renderpass, {p_benchmark->width, p_benchmark->height});
+	framebuffer->create(*renderpass, {colorImageView, depthImageView}, {p_benchmark->width, p_benchmark->height});
 
 	/*************************** pipeline shader stage ******************************/
 	ShaderPipelineState vertShaderState(VK_SHADER_STAGE_VERTEX_BIT, std::move(vertShader));
 	ShaderPipelineState fragShaderState(VK_SHADER_STAGE_FRAGMENT_BIT, std::move(fragShader));
 
 	/*************************** graphic pipeline creation **************************/
-	auto pipeline = std::make_unique<GraphicPipeline>(std::move(pipelineLayout));
-	pipeline->create({vertShaderState, fragShaderState}, pipelineState, *renderpass);
+	auto pipeline = std::make_unique<GraphicPipeline>(vulkan.device);
+	pipeline->create(pipelineLayout->getHandle(), {vertShaderState, fragShaderState}, pipelineState, *renderpass);
 
 	/****************************** save all resources ******************************/
 	p_benchmark->m_vertexBuffer = std::move(vertexBuffer);
@@ -307,6 +309,7 @@ int main(int argc, char** argv)
 	p_benchmark->m_bgSampler = std::move(bgSampler);
 	p_benchmark->m_bgImageView = std::move(bgImageView);
 	p_benchmark->m_descriptor = std::move(descriptor);
+	p_benchmark->m_pipelineLayout = std::move(pipelineLayout);
 
 	p_benchmark->m_pipeline = std::move(pipeline);
 
@@ -426,7 +429,7 @@ static void render(const vulkan_setup_t& vulkan)
 		vkCmdBindIndexBuffer(defaultCmd, p_benchmark->m_indexBuffer->getHandle(), 0, VK_INDEX_TYPE_UINT16);
 
 		VkDescriptorSet descriptor = p_benchmark->m_descriptor->getHandle();
-		vkCmdBindDescriptorSets(defaultCmd, VK_PIPELINE_BIND_POINT_GRAPHICS, p_benchmark->m_pipeline->m_pipelineLayout->getHandle(), 0, 1, &descriptor, 0, nullptr);
+		vkCmdBindDescriptorSets(defaultCmd, VK_PIPELINE_BIND_POINT_GRAPHICS, p_benchmark->m_pipelineLayout->getHandle(), 0, 1, &descriptor, 0, nullptr);
 
 		VkViewport viewport{};
 		viewport.x = 0.0f;

--- a/src/vulkan_graphics_common.cpp
+++ b/src/vulkan_graphics_common.cpp
@@ -205,7 +205,7 @@ VkResult TexelBufferView::create(VkFormat format, VkDeviceSize offsetInBytes/*= 
 	m_createInfo.offset                 = offsetInBytes;
 	m_createInfo.range                  = sizeInBytes;
 
-	VkResult result = vkCreateBufferView(m_pBuffer->m_device, &m_createInfo, nullptr, &m_handle);
+	VkResult result = vkCreateBufferView(m_pBuffer->getDevice(), &m_createInfo, nullptr, &m_handle);
 	check(result);
 	return result;
 }
@@ -356,7 +356,7 @@ VkResult ImageView::create(VkImageViewType viewType, VkImageAspectFlags aspect /
 	m_createInfo.subresourceRange.baseArrayLayer = 0;
 	m_createInfo.subresourceRange.layerCount = 1;
 
-	VkResult result = vkCreateImageView(m_pImage->m_device, &m_createInfo, nullptr, &m_handle);
+	VkResult result = vkCreateImageView(m_pImage->getDevice(), &m_createInfo, nullptr, &m_handle);
 	check(result);
 
 	return result;
@@ -367,7 +367,7 @@ VkResult ImageView::destroy()
 	VkResult result = VK_SUCCESS;
 	DLOG3("MEM detection: imageView destroy().");
 
-	vkDestroyImageView(m_pImage->m_device, m_handle, nullptr);
+	vkDestroyImageView(m_pImage->getDevice(), m_handle, nullptr);
 	m_handle = VK_NULL_HANDLE;
 	m_createInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, nullptr };
 
@@ -454,7 +454,7 @@ VkResult CommandBufferPool::destroy()
 CommandBuffer::CommandBuffer(std::shared_ptr<CommandBufferPool> commandBufferPool)
 	:m_pCommandBufferPool(commandBufferPool)
 {
-	m_device = commandBufferPool->m_device;
+	m_device = commandBufferPool->getDevice();
 }
 
 VkResult CommandBuffer::create(VkCommandBufferLevel commandBufferLevel)
@@ -518,16 +518,8 @@ void CommandBuffer::beginRenderPass(const RenderPass& renderPass, const FrameBuf
 	renderPassInfo.framebuffer = frameBuffer.getHandle();
 	renderPassInfo.renderArea.offset = {0, 0};
 	renderPassInfo.renderArea.extent = { frameBuffer.getCreateInfo().width, frameBuffer.getCreateInfo().height };
-
-	std::vector<VkClearValue> clearValues(renderPass.m_attachmentInfos.size());
-
-	for (auto& attachment : renderPass.m_attachmentInfos)
-	{
-		clearValues[attachment.m_location] = attachment.m_clear;
-	}
-
-	renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());;
-	renderPassInfo.pClearValues = clearValues.data();
+	renderPassInfo.clearValueCount = static_cast<uint32_t>(renderPass.getAttachmentClears().size());
+	renderPassInfo.pClearValues = renderPass.getAttachmentClears().data();
 
 	vkCmdBeginRenderPass(m_handle, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
 
@@ -678,14 +670,17 @@ VkResult RenderPass::create(const std::vector<AttachmentInfo>& attachments, cons
 
 VkResult RenderPass::create(uint32_t attachmentCount, const std::vector<AttachmentInfo>& attachments, uint32_t subpassCount, const std::vector<SubpassInfo>& subpasses)
 {
-	m_attachmentInfos = attachments;
-
-	m_attachmentDescriptions.resize(attachments.size());
-	for (auto& attachment : attachments)
+	m_attachmentDescriptions.assign(attachmentCount, VkAttachmentDescription{});
+	m_attachmentClears.assign(attachmentCount, VkClearValue{});
+	m_subpassDescriptions.clear();
+	m_subpassDescriptions.reserve(subpasses.size());
+	for (const auto& attachment : attachments)
+	{
 		m_attachmentDescriptions[attachment.m_location] = attachment.m_description;
+		m_attachmentClears[attachment.m_location] = attachment.m_clear;
+	}
 
-
-	for (auto& subpass : subpasses)
+	for (const auto& subpass : subpasses)
 	{
 		VkSubpassDescription subDescription{};
 
@@ -693,7 +688,7 @@ VkResult RenderPass::create(uint32_t attachmentCount, const std::vector<Attachme
 		subDescription.pipelineBindPoint = subpass.m_pipelineBindPoint;
 		subDescription.inputAttachmentCount = static_cast<uint32_t>(subpass.m_inputAttachments.size());
 		subDescription.pInputAttachments = subpass.m_inputAttachments.data();
-		subDescription.colorAttachmentCount = static_cast<uint32_t>(subpass.m_colorAttachments.size());;
+		subDescription.colorAttachmentCount = static_cast<uint32_t>(subpass.m_colorAttachments.size());
 		subDescription.pColorAttachments = subpass.m_colorAttachments.data();
 		subDescription.pResolveAttachments = subpass.m_resolveAttachments.data();
 		subDescription.pDepthStencilAttachment =
@@ -726,24 +721,36 @@ VkResult RenderPass::destroy()
 	m_handle = VK_NULL_HANDLE;
 
 	m_attachmentDescriptions.clear();
+	m_attachmentClears.clear();
 	m_subpassDescriptions.clear();
 	m_subpassDependencies.clear();
-
-	m_attachmentInfos.clear();
 
 	m_createInfo = { VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, nullptr };
 	return result;
 }
 
-VkResult FrameBuffer::create(const RenderPass& renderPass, VkExtent2D extent, uint32_t layers /*=1*/ )
+VkResult FrameBuffer::create(const RenderPass& renderPass, const std::vector<std::shared_ptr<ImageView>>& attachments,
+                             VkExtent2D extent, uint32_t layers /*=1*/ )
 {
-	uint32_t count = static_cast<uint32_t>(renderPass.m_attachmentInfos.size());
-	m_attachments.resize(count);
-	for (auto& attachment : renderPass.m_attachmentInfos)
-		m_attachments[attachment.m_location] = attachment.m_pImageView->getHandle();
+	const auto& attachmentDescriptions = renderPass.getAttachmentDescriptions();
+	assert(attachments.size() == attachmentDescriptions.size());
+	m_attachmentImageViews = attachments;
+	m_attachments.resize(attachments.size());
+	for (size_t i = 0; i < attachments.size(); ++i)
+	{
+		assert(m_attachmentImageViews[i]);
+		assert(m_attachmentImageViews[i]->m_pImage);
+		const auto imageCreateInfo = m_attachmentImageViews[i]->m_pImage->getCreateInfo();
+		assert(imageCreateInfo.format == attachmentDescriptions[i].format);
+		assert(imageCreateInfo.samples == attachmentDescriptions[i].samples);
+		assert(imageCreateInfo.extent.width >= extent.width);
+		assert(imageCreateInfo.extent.height >= extent.height);
+		assert(imageCreateInfo.arrayLayers >= layers);
+		m_attachments[i] = m_attachmentImageViews[i]->getHandle();
+	}
 
 	m_createInfo.renderPass = renderPass.getHandle();
-	m_createInfo.attachmentCount = count;
+	m_createInfo.attachmentCount = static_cast<uint32_t>(m_attachments.size());
 	m_createInfo.pAttachments = m_attachments.data();
 	m_createInfo.width = extent.width;
 	m_createInfo.height = extent.height;
@@ -763,6 +770,7 @@ VkResult FrameBuffer::destroy()
 	vkDestroyFramebuffer(m_device, m_handle, nullptr);
 	m_handle = VK_NULL_HANDLE;
 
+	m_attachmentImageViews.clear();
 	m_attachments.clear();
 	m_createInfo = { VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr };
 	return result;
@@ -1047,18 +1055,13 @@ void DescriptorSetLayout::insertNext<VkMutableDescriptorTypeCreateInfoEXT>(const
 	m_createInfoNexts.push_back((VkBaseInStructure*)pInfo);
 }
 
-VkResult DescriptorSetPool::create(uint32_t maxSets, VkDescriptorPoolCreateFlags flags /*=0*/)
+VkResult DescriptorSetPool::create(uint32_t maxSets, const std::vector<VkDescriptorPoolSize>& poolSizes, VkDescriptorPoolCreateFlags flags /*=0*/)
 {
-	std::vector<VkDescriptorSetLayoutBinding> bindings = m_pDescriptorSetLayout->getBindings();
-	for (auto& binding : bindings)
-	{
-		m_poolSizes.push_back({binding.descriptorType, binding.descriptorCount * maxSets});
-	}
-
+	m_poolSizes = { poolSizes.begin(), poolSizes.end() };
 	m_createInfo.flags = flags;
 	m_createInfo.poolSizeCount = static_cast<uint32_t>(m_poolSizes.size());
-	m_createInfo.pPoolSizes    = m_poolSizes.data();
-	m_createInfo.maxSets       = maxSets;
+	m_createInfo.pPoolSizes = m_poolSizes.data();
+	m_createInfo.maxSets = maxSets;
 	return create();
 }
 
@@ -1070,7 +1073,7 @@ VkResult DescriptorSetPool::create(const DescriptorPoolCreateFuncType& createFun
 
 VkResult DescriptorSetPool::create()
 {
-	VkResult result = vkCreateDescriptorPool(m_pDescriptorSetLayout->m_device, &m_createInfo, nullptr, &m_handle);
+	VkResult result = vkCreateDescriptorPool(m_device, &m_createInfo, nullptr, &m_handle);
 	check(result);
 	return result;
 }
@@ -1080,27 +1083,38 @@ VkResult DescriptorSetPool::destroy()
 	VkResult result = VK_SUCCESS;
 	DLOG3("MEM detection: descriptorSetPool destroy().");
 
-	vkDestroyDescriptorPool(m_pDescriptorSetLayout->m_device, m_handle, nullptr);
+	vkDestroyDescriptorPool(m_device, m_handle, nullptr);
 	m_handle = VK_NULL_HANDLE;
 
 	m_poolSizes.clear();
 	m_createInfo =  { VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO, nullptr };
-
-	m_pDescriptorSetLayout = nullptr;
 	return result;
 }
 
-VkResult DescriptorSet::create()
+VkResult DescriptorSet::create(VkDescriptorSetLayout layout, const std::vector<VkDescriptorSetLayoutBinding>& bindings)
 {
 	m_createInfo.pNext = m_pCreateInfoNext;
 	m_createInfo.descriptorPool = m_pDescriptorSetPool->getHandle();
 	m_createInfo.descriptorSetCount = 1;
-	std::vector<VkDescriptorSetLayout> setLayouts = {m_pDescriptorSetPool->m_pDescriptorSetLayout->getHandle()};
-	m_createInfo.pSetLayouts = setLayouts.data();
+	VkDescriptorSetAllocateInfo createInfo = m_createInfo;
+	createInfo.pSetLayouts = &layout;
 
-	VkResult result = vkAllocateDescriptorSets(m_pDescriptorSetPool->m_pDescriptorSetLayout->m_device, &m_createInfo, &m_handle);
+	m_bindings.clear();
+	for (const auto& binding : bindings)
+	{
+		auto [iter, inserted] = m_bindings.insert({ binding.binding, binding });
+		assert(inserted);
+		(void)iter;
+	}
+
+	VkResult result = vkAllocateDescriptorSets(m_device, &createInfo, &m_handle);
 	check(result);
 	return result;
+}
+
+VkResult DescriptorSet::create(const DescriptorSetLayout& layout)
+{
+	return create(layout.getHandle(), layout.getBindings());
 }
 
 void DescriptorSet::insertNext(const VkDescriptorSetVariableDescriptorCountAllocateInfo& next)
@@ -1120,127 +1134,200 @@ void DescriptorSet::insertNext(const VkDescriptorSetVariableDescriptorCountAlloc
 	m_createInfoNexts.push_back((VkBaseInStructure*)pInfo);
 }
 
-void DescriptorSet::setBuffer(uint32_t binding, const Buffer& buffer, VkDeviceSize offsetInBytes/*= 0*/, VkDeviceSize sizeInBytes/* = VK_WHOLE_SIZE*/)
+void DescriptorSet::setBuffer(uint32_t binding, uint32_t arrayElement, const Buffer& buffer, VkDeviceSize offsetInBytes/*= 0*/, VkDeviceSize sizeInBytes/* = VK_WHOLE_SIZE*/)
 {
 	VkDescriptorBufferInfo bufferInfo{};
 	bufferInfo.buffer = buffer.getHandle();
 	bufferInfo.offset = offsetInBytes;
 	bufferInfo.range = sizeInBytes;
 
-	m_setState.setBuffer(binding, bufferInfo);
+	m_writeData.setBuffer(binding, arrayElement, bufferInfo);
 }
 
-void DescriptorSet::setCombinedImageSampler(uint32_t binding, const ImageView& imageView, VkImageLayout imageLayout, const Sampler& sampler)
+void DescriptorSet::setBufferNullDescriptor(uint32_t binding, uint32_t arrayElement/*= 0*/)
 {
+	const auto& layout_binding = m_bindings.at(binding);
+	assert(layout_binding.descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER ||
+	       layout_binding.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER ||
+	       layout_binding.descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC ||
+	       layout_binding.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC);
 
+	VkDescriptorBufferInfo bufferInfo{};
+	bufferInfo.buffer = VK_NULL_HANDLE;
+	bufferInfo.offset = 0;
+	bufferInfo.range = VK_WHOLE_SIZE;
+
+	m_writeData.setBuffer(binding, arrayElement, bufferInfo);
+}
+
+void DescriptorSet::setCombinedImageSampler(uint32_t binding, uint32_t arrayElement, const ImageView& imageView, VkImageLayout imageLayout, const Sampler& sampler)
+{
 	VkDescriptorImageInfo imageInfo{};
 	imageInfo.sampler = sampler.getHandle();
 	imageInfo.imageView = imageView.getHandle();
 	imageInfo.imageLayout = imageLayout;
 
-	m_setState.setImage(binding, imageInfo);
+	m_writeData.setImage(binding, arrayElement, imageInfo);
 }
 
-void DescriptorSet::setImage(uint32_t binding, const ImageView& imageView, VkImageLayout imageLayout)
+void DescriptorSet::setCombinedImageSamplerNullDescriptor(uint32_t binding, uint32_t arrayElement, const Sampler& sampler, VkImageLayout imageLayout/*= VK_IMAGE_LAYOUT_UNDEFINED*/)
+{
+	const auto& layout_binding = m_bindings.at(binding);
+	assert(layout_binding.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+
+	VkDescriptorImageInfo imageInfo{};
+	imageInfo.sampler = sampler.getHandle();
+	imageInfo.imageView = VK_NULL_HANDLE;
+	imageInfo.imageLayout = imageLayout;
+
+	m_writeData.setImage(binding, arrayElement, imageInfo);
+}
+
+void DescriptorSet::setImage(uint32_t binding, uint32_t arrayElement, const ImageView& imageView, VkImageLayout imageLayout)
 {
 	VkDescriptorImageInfo imageInfo{};
 	imageInfo.sampler = VK_NULL_HANDLE;
 	imageInfo.imageView = imageView.getHandle();
 	imageInfo.imageLayout = imageLayout;
 
-	m_setState.setImage(binding, imageInfo);
+	m_writeData.setImage(binding, arrayElement, imageInfo);
 }
 
-void DescriptorSet::setSampler(uint32_t binding, const Sampler& sampler)
+void DescriptorSet::setImageNullDescriptor(uint32_t binding, uint32_t arrayElement/*= 0*/, VkImageLayout imageLayout/*= VK_IMAGE_LAYOUT_UNDEFINED*/)
+{
+	const auto& layout_binding = m_bindings.at(binding);
+	assert(layout_binding.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
+	       layout_binding.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE ||
+	       layout_binding.descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
+
+	VkDescriptorImageInfo imageInfo{};
+	imageInfo.sampler = VK_NULL_HANDLE;
+	imageInfo.imageView = VK_NULL_HANDLE;
+	imageInfo.imageLayout = imageLayout;
+
+	m_writeData.setImage(binding, arrayElement, imageInfo);
+}
+
+void DescriptorSet::setSampler(uint32_t binding, uint32_t arrayElement, const Sampler& sampler)
 {
 	VkDescriptorImageInfo imageInfo{};
 	imageInfo.sampler = sampler.getHandle();
 	imageInfo.imageView = VK_NULL_HANDLE;
 	imageInfo.imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-	m_setState.setImage(binding, imageInfo);
+	m_writeData.setImage(binding, arrayElement, imageInfo);
 }
 
-void DescriptorSet::setTexelBufferView(uint32_t binding, const TexelBufferView& bufferView)
+void DescriptorSet::setTexelBufferView(uint32_t binding, uint32_t arrayElement, const TexelBufferView& bufferView)
 {
-	m_setState.setBufferView(binding, bufferView.getHandle());
+	m_writeData.setBufferView(binding, arrayElement, bufferView.getHandle());
+}
+
+void DescriptorSet::setTexelBufferViewNullDescriptor(uint32_t binding, uint32_t arrayElement/*= 0*/)
+{
+	const auto& layout_binding = m_bindings.at(binding);
+	assert(layout_binding.descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER ||
+	       layout_binding.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
+	m_writeData.setBufferView(binding, arrayElement, VK_NULL_HANDLE);
 }
 
 void DescriptorSet::update()
 {
-	VkDescriptorType type;
-
-	for (auto& iter : m_setState.m_buffers)
+	std::vector<VkWriteDescriptorSet> writes;
+	size_t maxWriteCount = 0;
+	for (const auto& iter : m_writeData.m_buffers)
 	{
-		auto info = iter.second;
-		if (info.size() > 0)
-		{
-			if (info[0].buffer == VK_NULL_HANDLE) continue;
-
-			type = m_pDescriptorSetPool->m_pDescriptorSetLayout->getDescriptorType(iter.first);
-
-			VkWriteDescriptorSet writeDescriptor { VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr };
-
-			writeDescriptor.dstSet = m_handle;
-			writeDescriptor.dstBinding = iter.first;
-			writeDescriptor.dstArrayElement = 0;
-			writeDescriptor.descriptorCount = static_cast<uint32_t>(info.size());
-			writeDescriptor.descriptorType = type;
-			writeDescriptor.pBufferInfo = info.data();
-			writeDescriptor.pImageInfo = nullptr;
-			writeDescriptor.pTexelBufferView = nullptr;
-
-			vkUpdateDescriptorSets(m_pDescriptorSetPool->m_pDescriptorSetLayout->m_device, 1, &writeDescriptor, 0, nullptr);
-		}
+		maxWriteCount += iter.second.size();
 	}
-
-	for (auto& iter : m_setState.m_images)
+	for (const auto& iter : m_writeData.m_images)
 	{
-		auto info = iter.second;
-		if (info.size() > 0)
-		{
-			if (info[0].sampler == VK_NULL_HANDLE && info[0].imageView == VK_NULL_HANDLE)
-				continue;
-
-			type = m_pDescriptorSetPool->m_pDescriptorSetLayout->getDescriptorType(iter.first);
-
-			VkWriteDescriptorSet writeDescriptor { VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr };
-
-			writeDescriptor.dstSet = m_handle;
-			writeDescriptor.dstBinding = iter.first;
-			writeDescriptor.dstArrayElement = 0;
-			writeDescriptor.descriptorCount = static_cast<uint32_t>(info.size());
-			writeDescriptor.descriptorType = type;
-			writeDescriptor.pBufferInfo = nullptr;
-			writeDescriptor.pImageInfo = info.data();
-			writeDescriptor.pTexelBufferView = nullptr;
-
-			vkUpdateDescriptorSets(m_pDescriptorSetPool->m_pDescriptorSetLayout->m_device, 1, &writeDescriptor, 0, nullptr);
-		}
+		maxWriteCount += iter.second.size();
 	}
-
-	for (auto& iter : m_setState.m_bufferViews)
+	for (const auto& iter : m_writeData.m_bufferViews)
 	{
-		if (iter.second == VK_NULL_HANDLE) continue;
+		maxWriteCount += iter.second.size();
+	}
+	writes.reserve(maxWriteCount);
 
-		type = m_pDescriptorSetPool->m_pDescriptorSetLayout->getDescriptorType(iter.first);
+	std::deque<std::vector<VkDescriptorBufferInfo>> bufferWriteStorage;
+	std::deque<std::vector<VkDescriptorImageInfo>> imageWriteStorage;
+	std::deque<std::vector<VkBufferView>> bufferViewWriteStorage;
 
-		VkWriteDescriptorSet writeDescriptor { VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr };
+	collectDescriptorWrites(m_writeData.m_buffers, bufferWriteStorage, writes,
+	                      [](VkWriteDescriptorSet& writeDescriptor, const VkDescriptorBufferInfo* data)
+	                      {
+		                      writeDescriptor.pBufferInfo = data;
+	                      });
 
-		writeDescriptor.dstSet = m_handle;
-		writeDescriptor.dstBinding = iter.first;
-		writeDescriptor.dstArrayElement = 0;
-		writeDescriptor.descriptorCount = 1;
-		writeDescriptor.descriptorType = type;
-		writeDescriptor.pBufferInfo = nullptr;
-		writeDescriptor.pImageInfo = nullptr;
-		writeDescriptor.pTexelBufferView = &iter.second;
+	collectDescriptorWrites(m_writeData.m_images, imageWriteStorage, writes,
+	                      [](VkWriteDescriptorSet& writeDescriptor, const VkDescriptorImageInfo* data)
+	                      {
+		                      writeDescriptor.pImageInfo = data;
+	                      });
 
-		vkUpdateDescriptorSets(m_pDescriptorSetPool->m_pDescriptorSetLayout->m_device, 1, &writeDescriptor, 0, nullptr);
+	collectDescriptorWrites(m_writeData.m_bufferViews, bufferViewWriteStorage, writes,
+	                      [](VkWriteDescriptorSet& writeDescriptor, const VkBufferView* data)
+	                      {
+		                      writeDescriptor.pTexelBufferView = data;
+	                      });
+
+	if (!writes.empty())
+	{
+		vkUpdateDescriptorSets(m_device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
 	}
 
 	// AS TBD
 }
+
+template <typename T, typename AssignWritePointer>
+void DescriptorSet::collectDescriptorWrites(
+    const tracetooltests::DescriptorSetWriteData::BindingWriteMap<T>& bindingWrites,
+    std::deque<std::vector<T>>& contiguousWriteStorage,
+    std::vector<VkWriteDescriptorSet>& writes,
+    AssignWritePointer assignWritePointer) const
+{
+	for (const auto& bindingWrite : bindingWrites)
+	{
+		if (bindingWrite.second.empty()) continue;
+		const uint32_t bindingIndex = bindingWrite.first;
+		const auto& binding = m_bindings.at(bindingIndex);
+
+		for (auto iter = bindingWrite.second.begin(); iter != bindingWrite.second.end();)
+		{
+			assert(iter->first < binding.descriptorCount);
+			auto runBegin = iter;
+			contiguousWriteStorage.emplace_back();
+			auto& runValues = contiguousWriteStorage.back();
+			runValues.push_back(iter->second);
+
+			// Merge consecutive array elements into one VkWriteDescriptorSet.
+			uint32_t previousArrayElement = iter->first;
+			++iter;
+			while (iter != bindingWrite.second.end())
+			{
+				assert(iter->first < binding.descriptorCount);
+				if (iter->first != previousArrayElement + 1) break;
+				runValues.push_back(iter->second);
+				previousArrayElement = iter->first;
+				++iter;
+			}
+
+			// std::map storage is not contiguous, so each merged run needs its own vector backing.
+			VkWriteDescriptorSet writeDescriptor{ VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, nullptr };
+			writeDescriptor.dstSet = m_handle;
+			writeDescriptor.dstBinding = bindingIndex;
+			writeDescriptor.dstArrayElement = runBegin->first;
+			writeDescriptor.descriptorCount = static_cast<uint32_t>(runValues.size());
+			writeDescriptor.descriptorType = binding.descriptorType;
+			writeDescriptor.pBufferInfo = nullptr;
+			writeDescriptor.pImageInfo = nullptr;
+			writeDescriptor.pTexelBufferView = nullptr;
+			assignWritePointer(writeDescriptor, runValues.data());
+			writes.push_back(writeDescriptor);
+		}
+	}
+}
+
 
 VkResult DescriptorSet::destroy()
 {
@@ -1251,9 +1338,9 @@ VkResult DescriptorSet::destroy()
 
 	m_createInfo = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO, nullptr };
 
-	m_setState.m_buffers.clear();
-	m_setState.m_images.clear();
-	m_setState.m_bufferViews.clear();
+	m_writeData.m_buffers.clear();
+	m_writeData.m_images.clear();
+	m_writeData.m_bufferViews.clear();
 
 	for (auto& next : m_createInfoNexts)
 	{
@@ -1262,48 +1349,28 @@ VkResult DescriptorSet::destroy()
 	m_createInfoNexts.clear();
 	m_pCreateInfoNext = nullptr;
 	m_variabledSizeDescriptorCount.clear();
+	m_bindings.clear();
 
 	return result;
 }
 
-VkResult PipelineLayout::create(const std::unordered_map<uint32_t,std::shared_ptr<DescriptorSetLayout>>& setLayoutMap, const std::vector<VkPushConstantRange>& pushConstantRanges/*={}*/)
+VkResult PipelineLayout::create(const std::vector<VkDescriptorSetLayout>& setLayouts, const std::vector<VkPushConstantRange>& pushConstantRanges/*={}*/)
 {
-	return create(setLayoutMap.size(), setLayoutMap, pushConstantRanges.size(), pushConstantRanges);
+	m_descriptorSetLayouts = {setLayouts.begin(), setLayouts.end()};
+	m_pushConstantRanges   = {pushConstantRanges.begin(), pushConstantRanges.end()};
+	return create();
 }
-
 VkResult PipelineLayout::create(const std::vector<VkPushConstantRange>& pushConstantRanges)
 {
 	m_pushConstantRanges = {pushConstantRanges.begin(), pushConstantRanges.end()};
-	return create(m_descriptorSetLayouts.size(), m_pushConstantRanges.size());
+	return create();
 }
 
-VkResult PipelineLayout::create(uint32_t setLayoutCount, const std::unordered_map<uint32_t,std::shared_ptr<DescriptorSetLayout>>& setLayoutMap, uint32_t pushConstantRangeCount, const std::vector<VkPushConstantRange>& pushConstantRanges)
+VkResult PipelineLayout::create()
 {
-	m_pDescriptorSetLayouts.clear();
-	m_descriptorSetLayouts.clear();
-
-	uint32_t layoutCount = setLayoutCount;
-	if (layoutCount == 0) layoutCount = setLayoutMap.size();
-	for (const auto& setLayout : setLayoutMap)
-	{
-		if (setLayout.first + 1 > layoutCount) layoutCount = setLayout.first + 1;
-	}
-	m_descriptorSetLayouts.assign(layoutCount, VK_NULL_HANDLE);
-	for (const auto& setLayout: setLayoutMap)
-	{
-		m_pDescriptorSetLayouts[setLayout.first] = setLayout.second;
-		m_descriptorSetLayouts[setLayout.first] = setLayout.second->getHandle();
-	}
-	m_pushConstantRanges = {pushConstantRanges.begin(), pushConstantRanges.end()};
-
-	return create(static_cast<uint32_t>(m_descriptorSetLayouts.size()), pushConstantRangeCount);
-}
-
-VkResult PipelineLayout::create(uint32_t layoutCount, uint32_t constantCount)
-{
-	m_createInfo.setLayoutCount = layoutCount;
+	m_createInfo.setLayoutCount = static_cast<uint32_t>(m_descriptorSetLayouts.size());
 	m_createInfo.pSetLayouts = m_descriptorSetLayouts.data();
-	m_createInfo.pushConstantRangeCount = constantCount;
+	m_createInfo.pushConstantRangeCount = static_cast<uint32_t>(m_pushConstantRanges.size());
 	m_createInfo.pPushConstantRanges = m_pushConstantRanges.data();
 
 	VkResult result = vkCreatePipelineLayout(m_device, &m_createInfo, nullptr, &m_handle);
@@ -1316,8 +1383,6 @@ VkResult PipelineLayout::destroy()
 	VkResult result = VK_SUCCESS;
 	DLOG3("MEM detection: pipelineLayout destroy().");
 
-	m_pDescriptorSetLayouts.clear();
-
 	vkDestroyPipelineLayout(m_device, m_handle, nullptr);
 	m_handle = VK_NULL_HANDLE;
 
@@ -1328,9 +1393,11 @@ VkResult PipelineLayout::destroy()
 	return result;
 }
 
-VkResult GraphicPipeline::create(const std::vector<ShaderPipelineState>& shaderStages, const GraphicPipelineState& graphicPipelineState, const RenderPass& renderPass, VkPipelineCreateFlags flags/* = 0*/, uint32_t subpassIndex /*=0*/)
+VkResult GraphicPipeline::create(VkPipelineLayout layout, const std::vector<ShaderPipelineState>& shaderStages, const GraphicPipelineState& graphicPipelineState, const RenderPass& renderPass, VkPipelineCreateFlags flags/* = 0*/, uint32_t subpassIndex /*=0*/)
 {
 	/* store resources to local storage, so that the objects in param list could be released */
+	assert(m_device != VK_NULL_HANDLE);
+	assert(layout != VK_NULL_HANDLE);
 
 	// shader stage
 	uint32_t count = static_cast<uint32_t>(shaderStages.size());
@@ -1364,7 +1431,6 @@ VkResult GraphicPipeline::create(const std::vector<ShaderPipelineState>& shaderS
 
 			m_shaderStageCreateInfos[index].pSpecializationInfo = &m_specializationInfos[index];
 		}
-		m_shaders[info.stage] = shaderStages[index].m_pShader;
 	}
 
 	// vertex input
@@ -1449,13 +1515,13 @@ VkResult GraphicPipeline::create(const std::vector<ShaderPipelineState>& shaderS
 	m_createInfo.pColorBlendState = &m_colorBlendStateCreateInfo;
 	m_createInfo.pViewportState = &m_viewportStateCreateInfo;
 
-	m_createInfo.layout = m_pipelineLayout->getHandle();
+	m_createInfo.layout = layout;
 	m_createInfo.renderPass = renderPass.getHandle();
 	m_createInfo.subpass = subpassIndex;
 	m_createInfo.basePipelineHandle = VK_NULL_HANDLE;
 	m_createInfo.basePipelineIndex = -1;
 
-	VkResult result = vkCreateGraphicsPipelines(m_pipelineLayout->m_device, VK_NULL_HANDLE, 1, &m_createInfo, nullptr, &m_handle);
+	VkResult result = vkCreateGraphicsPipelines(m_device, VK_NULL_HANDLE, 1, &m_createInfo, nullptr, &m_handle);
 
 	check(result);
 	return result;
@@ -1466,7 +1532,7 @@ VkResult GraphicPipeline::destroy()
 	VkResult result = VK_SUCCESS;
 	DLOG3("MEM detection: graphicPipeline destroy().");
 
-	vkDestroyPipeline(m_pipelineLayout->m_device, m_handle, nullptr);
+	vkDestroyPipeline(m_device, m_handle, nullptr);
 	m_handle = VK_NULL_HANDLE;
 
 	m_specializationData.clear();
@@ -1494,8 +1560,6 @@ VkResult GraphicPipeline::destroy()
 	m_dynamicStateCreateInfo = { VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO, nullptr };
 	m_createInfo = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO, nullptr };
 
-	m_shaders.clear();
-	m_pipelineLayout = nullptr;
 
 	return result;
 }
@@ -1505,9 +1569,11 @@ bool GraphicPipeline::hasDynamicState(VkDynamicState dynamic) const
 	return std::binary_search(m_dynamicStates.begin(), m_dynamicStates.end(), dynamic);
 }
 
-VkResult ComputePipeline::create(const ShaderPipelineState& shaderStage, VkPipelineCreateFlags flags/* = 0*/)
+VkResult ComputePipeline::create(VkPipelineLayout layout, const ShaderPipelineState& shaderStage, VkPipelineCreateFlags flags/* = 0*/)
 {
 	/* store resources to local storage, so that the objects in param list could be released */
+	assert(m_device != VK_NULL_HANDLE);
+	assert(layout != VK_NULL_HANDLE);
 
 	// shader stage
 	m_shaderStageCreateInfo = shaderStage.getCreateInfo();
@@ -1530,15 +1596,13 @@ VkResult ComputePipeline::create(const ShaderPipelineState& shaderStage, VkPipel
 
 		m_shaderStageCreateInfo.pSpecializationInfo = &m_specializationInfo;
 	}
-	m_shader = shaderStage.m_pShader;
-
 	m_createInfo.flags = flags;
 	m_createInfo.stage = m_shaderStageCreateInfo;
-	m_createInfo.layout = m_pipelineLayout->getHandle();
+	m_createInfo.layout = layout;
 	m_createInfo.basePipelineHandle = VK_NULL_HANDLE;
 	m_createInfo.basePipelineIndex = -1;
 
-	VkResult result = vkCreateComputePipelines(m_pipelineLayout->m_device, VK_NULL_HANDLE, 1, &m_createInfo, nullptr, &m_handle);
+	VkResult result = vkCreateComputePipelines(m_device, VK_NULL_HANDLE, 1, &m_createInfo, nullptr, &m_handle);
 
 	check(result);
 	return result;
@@ -1549,15 +1613,12 @@ VkResult ComputePipeline::destroy()
 	VkResult result = VK_SUCCESS;
 	DLOG3("MEM detection: computePipeline destroy().");
 
-	vkDestroyPipeline(m_pipelineLayout->m_device, m_handle, nullptr);
+	vkDestroyPipeline(m_device, m_handle, nullptr);
 	m_handle = VK_NULL_HANDLE;
 
 	m_createInfo = { VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO, nullptr };
 	m_specializationMapEntries.clear();
 	m_specializationData.clear();
-
-	m_shader = nullptr;
-	m_pipelineLayout = nullptr;
 
 	return result;
 }
@@ -1715,31 +1776,33 @@ bool GraphicContext::saveImageOutput()
 	{
 		return false;
 	}
-	assert(m_renderPass);
-	assert(!m_renderPass->m_attachmentInfos.empty());
+	assert(m_framebuffer);
+	assert(!m_framebuffer->getAttachmentImageViews().empty());
 
-	AttachmentInfo* colorAttachment = nullptr;
-	for (auto& attachment : m_renderPass->m_attachmentInfos)
+	const ImageView* colorAttachmentImageView = nullptr;
+	uint32_t colorAttachmentIndex = VK_ATTACHMENT_UNUSED;
+	for (uint32_t i = 0; i < m_framebuffer->getAttachmentImageViews().size(); ++i)
 	{
-		if (!attachment.m_pImageView || !attachment.m_pImageView->m_pImage)
+		const auto& attachmentImageView = m_framebuffer->getAttachmentImageViews()[i];
+		if (!attachmentImageView || !attachmentImageView->m_pImage)
 		{
 			continue;
 		}
-		if (attachment.m_pImageView->m_pImage->m_aspect & VK_IMAGE_ASPECT_COLOR_BIT)
+		if (attachmentImageView->m_pImage->m_aspect & VK_IMAGE_ASPECT_COLOR_BIT)
 		{
-			colorAttachment = &attachment;
+			colorAttachmentImageView = attachmentImageView.get();
+			colorAttachmentIndex = i;
 			break;
 		}
 	}
-	assert(colorAttachment);
-	assert(colorAttachment->m_pImageView);
-	assert(colorAttachment->m_pImageView->m_pImage);
-	if (!colorAttachment || !colorAttachment->m_pImageView || !colorAttachment->m_pImageView->m_pImage)
+	assert(colorAttachmentImageView);
+	assert(colorAttachmentImageView->m_pImage);
+	if (!colorAttachmentImageView || !colorAttachmentImageView->m_pImage)
 	{
 		return false;
 	}
 
-	Image& image = *colorAttachment->m_pImageView->m_pImage;
+	Image& image = *colorAttachmentImageView->m_pImage;
 	assert(image.m_aspect & VK_IMAGE_ASPECT_COLOR_BIT);
 	VkFormat format = image.m_format;
 	const bool format_ok = format == VK_FORMAT_R8G8B8A8_UNORM || format == VK_FORMAT_R8G8B8A8_SRGB ||
@@ -1773,10 +1836,14 @@ bool GraphicContext::saveImageOutput()
 		m_secondCommandBuffer->create(VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 	}
 
-	VkImageLayout originalLayout = colorAttachment->m_description.finalLayout;
-	if (originalLayout == VK_IMAGE_LAYOUT_UNDEFINED)
+	VkImageLayout originalLayout = image.m_imageLayout;
+	if (m_renderPass && colorAttachmentIndex < m_renderPass->getAttachmentDescriptions().size())
 	{
-		originalLayout = image.m_imageLayout;
+		const VkImageLayout finalLayout = m_renderPass->getAttachmentDescriptions()[colorAttachmentIndex].finalLayout;
+		if (finalLayout != VK_IMAGE_LAYOUT_UNDEFINED)
+		{
+			originalLayout = finalLayout;
+		}
 	}
 	assert(originalLayout != VK_IMAGE_LAYOUT_UNDEFINED);
 	if (originalLayout == VK_IMAGE_LAYOUT_UNDEFINED)

--- a/src/vulkan_graphics_common.h
+++ b/src/vulkan_graphics_common.h
@@ -3,6 +3,8 @@
 #include "vulkan_common.h"
 #include <memory>
 #include <functional>
+#include <map>
+#include <deque>
 
 namespace tracetooltests
 {
@@ -45,14 +47,17 @@ public:
 	inline VkDeviceSize getSize() const {
 		return m_size;
 	}
+	inline VkDevice getDevice() const {
+		return m_device;
+	}
 
 	/* user definition createinfo: could used in corner cases, eg garbage data */
 	VkResult create(const BufferCreateInfoFunc& createInfoFunc, const AllocationCreateInfoFunc& allocationInfoFunc);
 
-	VkDevice m_device;
 	void* m_mappedAddress = nullptr;
 
 private:
+	VkDevice m_device;
 	VkResult create();
 
 	bool emit_extra_flushes = false;
@@ -117,13 +122,16 @@ public:
 	inline VkImageCreateInfo getCreateInfo() const {
 		return m_createInfo;
 	}
+	inline VkDevice getDevice() const {
+		return m_device;
+	}
 
-	VkDevice m_device;
 	VkFormat m_format = VK_FORMAT_UNDEFINED;
 	VkImageAspectFlags m_aspect = VK_IMAGE_ASPECT_NONE;
 	VkImageLayout m_imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
 private:
+	VkDevice m_device;
 	void setAspectMask(VkFormat format);
 	VkImageType findImageType(VkExtent3D extent) const;
 
@@ -173,9 +181,8 @@ public:
 		return m_handle;
 	}
 
-	VkDevice m_device;
-
 private:
+	VkDevice m_device;
 	VkResult create();
 
 	VkSampler m_handle = VK_NULL_HANDLE;
@@ -196,10 +203,12 @@ public:
 	inline VkCommandPool getHandle() const {
 		return m_handle;
 	}
-
-	VkDevice m_device;
+	inline VkDevice getDevice() const {
+		return m_device;
+	}
 
 private:
+	VkDevice m_device;
 	VkCommandPool m_handle = VK_NULL_HANDLE;
 	VkCommandPoolCreateInfo m_createInfo { VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO, nullptr };
 };
@@ -235,9 +244,9 @@ public:
 	}
 
 	std::shared_ptr<CommandBufferPool> m_pCommandBufferPool;
-	VkDevice m_device;
 
 private:
+	VkDevice m_device;
 	VkCommandBuffer m_handle = VK_NULL_HANDLE;
 	VkCommandBufferAllocateInfo m_createInfo { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, nullptr };
 };
@@ -303,9 +312,8 @@ public:
 		return m_handle;
 	}
 
-	VkDevice m_device;
-
 private:
+	VkDevice m_device;
 	VkResult create();
 
 	VkShaderModule m_handle = VK_NULL_HANDLE;
@@ -345,9 +353,8 @@ public:
 		return m_bindings;
 	}
 
-	VkDevice m_device;
-
 private:
+	VkDevice m_device;
 	VkDescriptorSetLayout m_handle = VK_NULL_HANDLE;
 	VkDescriptorSetLayoutCreateInfo m_createInfo { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, nullptr};
 	std::vector<VkDescriptorSetLayoutBinding> m_bindings; // the real inserted bindings.
@@ -365,70 +372,81 @@ class DescriptorSetPool
 public:
 	using DescriptorPoolCreateFuncType = std::function<void(VkDescriptorPoolCreateInfo&)>;
 
-	DescriptorSetPool(std::shared_ptr<DescriptorSetLayout> descSetLayout)
-		: m_pDescriptorSetLayout(descSetLayout) { }
+	DescriptorSetPool(VkDevice device)
+		: m_device(device) { }
 	~DescriptorSetPool() {
 		destroy();
 	}
 
-	VkResult create(uint32_t maxSets, VkDescriptorPoolCreateFlags flags = 0);
+	VkResult create(uint32_t maxSets, const std::vector<VkDescriptorPoolSize>& poolSizes, VkDescriptorPoolCreateFlags flags = 0);
 	VkResult create(const DescriptorPoolCreateFuncType& createFunc);
 	VkResult destroy();
 
 	inline VkDescriptorPool getHandle() const {
 		return m_handle;
 	}
-
-	std::shared_ptr<DescriptorSetLayout> m_pDescriptorSetLayout;
+	inline VkDevice getDevice() const {
+		return m_device;
+	}
 
 private:
 	VkResult create();
+	VkDevice m_device = VK_NULL_HANDLE;
 	VkDescriptorPool m_handle = VK_NULL_HANDLE;
 	VkDescriptorPoolCreateInfo m_createInfo { VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO, nullptr };
 	std::vector<VkDescriptorPoolSize> m_poolSizes;
 };
 
-typedef struct DescriptorSetState
+typedef struct DescriptorSetWriteData
 {
-	std::unordered_map<uint32_t, std::vector<VkDescriptorBufferInfo>> m_buffers; // binding -> info
-	std::unordered_map<uint32_t, std::vector<VkDescriptorImageInfo>> m_images;
-	std::unordered_map<uint32_t, VkBufferView> m_bufferViews;
+	template <typename T>
+	using BindingWriteMap = std::map<uint32_t, std::map<uint32_t, T>>;
+
+	BindingWriteMap<VkDescriptorBufferInfo> m_buffers; // binding -> arrayElement -> info
+	BindingWriteMap<VkDescriptorImageInfo> m_images;
+	BindingWriteMap<VkBufferView> m_bufferViews;
 	// acceleration Structure related
 
-	DescriptorSetState() {}
-	void setBuffer(uint32_t binding, const VkDescriptorBufferInfo& info)
+	DescriptorSetWriteData() {}
+	void setBuffer(uint32_t binding, uint32_t arrayElement, const VkDescriptorBufferInfo& info)
 	{
-		m_buffers[binding].emplace_back(info);
+		m_buffers[binding][arrayElement] = info;
 	}
-	void setImage(uint32_t binding, const VkDescriptorImageInfo& info)
+	void setImage(uint32_t binding, uint32_t arrayElement, const VkDescriptorImageInfo& info)
 	{
-		m_images[binding].emplace_back(info);
+		m_images[binding][arrayElement] = info;
 	}
-	void setBufferView(uint32_t binding, const VkBufferView& view)
+	void setBufferView(uint32_t binding, uint32_t arrayElement, const VkBufferView& view)
 	{
-		m_bufferViews[binding] = view;
+		m_bufferViews[binding][arrayElement] = view;
 	}
-} DescriptorSetState;
+} DescriptorSetWriteData;
 
 class DescriptorSet
 {
 public:
 	DescriptorSet(std::shared_ptr<DescriptorSetPool> pool)
-		: m_pDescriptorSetPool(pool) { };
+		: m_pDescriptorSetPool(pool), m_device(pool->getDevice()) { };
 	~DescriptorSet() {
 		destroy();
 	}
 
-	VkResult create();
+	VkResult create(VkDescriptorSetLayout layout, const std::vector<VkDescriptorSetLayoutBinding>& bindings);
+	VkResult create(const DescriptorSetLayout& layout);
 	VkResult destroy();
 	void insertNext(const VkDescriptorSetVariableDescriptorCountAllocateInfo& next);
 
 	void update();
-	void setBuffer(uint32_t binding, const Buffer& buffer, VkDeviceSize offsetInBytes = 0, VkDeviceSize sizeInBytes = VK_WHOLE_SIZE);
-	void setCombinedImageSampler(uint32_t binding, const ImageView& imageView, VkImageLayout imageLayout, const Sampler& sampler);
-	void setImage(uint32_t binding, const ImageView& imageView, VkImageLayout imageLayout);
-	void setSampler(uint32_t binding, const Sampler& sampler);
-	void setTexelBufferView(uint32_t binding, const TexelBufferView& bufferView);
+	// arrayElement selects which descriptor array element within the binding to update.
+	void setBuffer(uint32_t binding, uint32_t arrayElement, const Buffer& buffer, VkDeviceSize offsetInBytes = 0, VkDeviceSize sizeInBytes = VK_WHOLE_SIZE);
+	void setBufferNullDescriptor(uint32_t binding, uint32_t arrayElement = 0);
+	void setCombinedImageSampler(uint32_t binding, uint32_t arrayElement, const ImageView& imageView, VkImageLayout imageLayout, const Sampler& sampler);
+	void setCombinedImageSamplerNullDescriptor(uint32_t binding, uint32_t arrayElement, const Sampler& sampler, VkImageLayout imageLayout = VK_IMAGE_LAYOUT_UNDEFINED);
+	void setImage(uint32_t binding, uint32_t arrayElement, const ImageView& imageView, VkImageLayout imageLayout);
+	void setImageNullDescriptor(uint32_t binding, uint32_t arrayElement = 0, VkImageLayout imageLayout = VK_IMAGE_LAYOUT_UNDEFINED);
+	void setSampler(uint32_t binding, uint32_t arrayElement, const Sampler& sampler);
+	void setTexelBufferView(uint32_t binding, uint32_t arrayElement, const TexelBufferView& bufferView);
+	void setTexelBufferViewNullDescriptor(uint32_t binding, uint32_t arrayElement = 0);
 	void setAccelerationStructure();
 
 	inline VkDescriptorSet getHandle() const {
@@ -436,9 +454,17 @@ public:
 	}
 
 	std::shared_ptr<DescriptorSetPool> m_pDescriptorSetPool;
-	DescriptorSetState m_setState {};
+	DescriptorSetWriteData m_writeData {};
 
 private:
+	template <typename T, typename AssignWritePointer>
+	void collectDescriptorWrites(const DescriptorSetWriteData::BindingWriteMap<T>& bindingWrites,
+	                             std::deque<std::vector<T>>& contiguousWriteStorage,
+	                             std::vector<VkWriteDescriptorSet>& writes,
+	                             AssignWritePointer assignWritePointer) const;
+
+	VkDevice m_device = VK_NULL_HANDLE;
+	std::unordered_map<uint32_t, VkDescriptorSetLayoutBinding> m_bindings;
 	VkDescriptorSet m_handle = VK_NULL_HANDLE;
 	VkDescriptorSetAllocateInfo m_createInfo { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO, nullptr };
 
@@ -455,21 +481,17 @@ public:
 		destroy();
 	}
 
-	VkResult create(const std::unordered_map<uint32_t,std::shared_ptr<DescriptorSetLayout>>& setLayoutMap, const std::vector<VkPushConstantRange>& pushConstantRanges = {});
+	VkResult create(const std::vector<VkDescriptorSetLayout>& setLayouts, const std::vector<VkPushConstantRange>& pushConstantRanges = {});
 	VkResult create(const std::vector<VkPushConstantRange>& pushConstantRanges);
-	VkResult create(uint32_t setLayoutCount, const std::unordered_map<uint32_t,std::shared_ptr<DescriptorSetLayout>>& setLayoutMap,
-	                uint32_t pushConstantRangeCount, const std::vector<VkPushConstantRange>& pushConstantRanges);
 	VkResult destroy();
 
 	inline VkPipelineLayout getHandle() const {
 		return m_handle;
 	}
 
-	VkDevice m_device;
-	std::unordered_map<uint32_t, std::shared_ptr<DescriptorSetLayout>> m_pDescriptorSetLayouts; // set -> setLayout
-
 private:
-	VkResult create(uint32_t layoutCount, uint32_t constantCount);
+	VkDevice m_device;
+	VkResult create();
 
 	VkPipelineLayout m_handle = VK_NULL_HANDLE;
 	VkPipelineLayoutCreateInfo m_createInfo{ VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO, nullptr };
@@ -482,7 +504,6 @@ class AttachmentInfo
 {
 public:
 	uint32_t m_location;
-	std::shared_ptr<ImageView> m_pImageView; // we need some members of ImageView
 	VkAttachmentDescription m_description;
 	VkClearValue m_clear;
 
@@ -497,12 +518,12 @@ public:
 		m_clear.depthStencil.stencil = 0;
 	}
 
-	AttachmentInfo(uint32_t location, std::shared_ptr<ImageView> imageView, VkImageLayout finalLayout) : AttachmentInfo()
+	AttachmentInfo(uint32_t location, const ImageView& imageView, VkImageLayout finalLayout) : AttachmentInfo()
 	{
 		m_location = location;
-		m_pImageView = imageView;
+		assert(imageView.m_pImage);
 
-		VkImageCreateInfo createInfo = m_pImageView->m_pImage->getCreateInfo();
+		const VkImageCreateInfo createInfo = imageView.m_pImage->getCreateInfo();
 
 		m_description.format = createInfo.format;
 		m_description.samples = createInfo.samples;
@@ -519,7 +540,6 @@ public:
 	{
 		DLOG3("MEM detection: attacmentInfo destroy().");
 		resetDescription();
-		m_pImageView = nullptr;
 		return VK_SUCCESS;
 	}
 
@@ -586,15 +606,20 @@ public:
 	inline VkRenderPass getHandle() const {
 		return m_handle;
 	}
-
-	VkDevice m_device;
-	std::vector<AttachmentInfo> m_attachmentInfos;
+	inline const std::vector<VkAttachmentDescription>& getAttachmentDescriptions() const {
+		return m_attachmentDescriptions;
+	}
+	inline const std::vector<VkClearValue>& getAttachmentClears() const {
+		return m_attachmentClears;
+	}
 
 private:
+	VkDevice m_device;
 	VkRenderPass m_handle = VK_NULL_HANDLE;
 	VkRenderPassCreateInfo m_createInfo { VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, nullptr };
 
 	std::vector<VkAttachmentDescription> m_attachmentDescriptions;
+	std::vector<VkClearValue> m_attachmentClears;
 	std::vector<VkSubpassDescription> m_subpassDescriptions;
 	std::vector<VkSubpassDependency> m_subpassDependencies;
 };
@@ -609,7 +634,8 @@ public:
 		destroy();
 	}
 
-	VkResult create(const RenderPass& renderPass, VkExtent2D extent, uint32_t layers = 1);
+	VkResult create(const RenderPass& renderPass, const std::vector<std::shared_ptr<ImageView>>& attachments,
+	                VkExtent2D extent, uint32_t layers = 1);
 	VkResult destroy();
 
 	inline VkFramebuffer getHandle() const {
@@ -618,14 +644,17 @@ public:
 	inline VkFramebufferCreateInfo getCreateInfo() const {
 		return m_createInfo;
 	}
+	inline const std::vector<std::shared_ptr<ImageView>>& getAttachmentImageViews() const {
+		return m_attachmentImageViews;
+	}
 
 	VkResult create(const FrameBufferCreateInfoFunc& createInfoFunc);
 
-	VkDevice m_device;
-
 private:
+	VkDevice m_device;
 	VkFramebuffer m_handle = VK_NULL_HANDLE;
 	VkFramebufferCreateInfo m_createInfo { VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr };
+	std::vector<std::shared_ptr<ImageView>> m_attachmentImageViews;
 	std::vector<VkImageView> m_attachments;
 };
 
@@ -644,9 +673,9 @@ public:
 		return m_createInfo;
 	}
 
+private:
 	std::shared_ptr<Shader> m_pShader;
 
-private:
 	std::string m_entry;
 	VkPipelineShaderStageCreateInfo m_createInfo { VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, nullptr};
 	VkSpecializationInfo m_specializationInfo {};
@@ -707,21 +736,20 @@ private:
 class GraphicPipeline
 {
 public:
-	GraphicPipeline(std::shared_ptr<PipelineLayout> pipelineLayout) : m_pipelineLayout(pipelineLayout) {}
+	GraphicPipeline(VkDevice device) : m_device(device) {}
 	~GraphicPipeline() {
 		destroy();
 	}
 
-	VkResult create(const std::vector<ShaderPipelineState>& shaderStages, const GraphicPipelineState& graphicPipelineState, const RenderPass& renderPass, VkPipelineCreateFlags flags = 0,uint32_t subpassIndex = 0);
+	VkResult create(VkPipelineLayout layout, const std::vector<ShaderPipelineState>& shaderStages, const GraphicPipelineState& graphicPipelineState, const RenderPass& renderPass, VkPipelineCreateFlags flags = 0, uint32_t subpassIndex = 0);
 	VkResult destroy();
 	bool hasDynamicState(VkDynamicState dynamic) const;
 	inline VkPipeline getHandle() const {
 		return m_handle;
 	}
 
-	std::shared_ptr<PipelineLayout> m_pipelineLayout;
-
 private:
+	VkDevice m_device = VK_NULL_HANDLE;
 	VkPipeline m_handle = VK_NULL_HANDLE;
 	VkGraphicsPipelineCreateInfo m_createInfo{ VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO, nullptr };
 
@@ -731,7 +759,6 @@ private:
 	std::vector<VkSpecializationInfo>                  m_specializationInfos;
 	std::vector<std::vector<VkSpecializationMapEntry>> m_specializationMapEntries;
 	std::vector<std::vector<char>>                     m_specializationData;
-	std::unordered_map<VkShaderStageFlagBits, std::shared_ptr<Shader>> m_shaders;
 
 	VkPipelineVertexInputStateCreateInfo               m_vertexInputStateCreateInfo;
 	std::vector<VkVertexInputBindingDescription>       m_vertexInputBindingDescriptions;
@@ -760,13 +787,13 @@ private:
 class ComputePipeline
 {
 public:
-	ComputePipeline(std::shared_ptr<PipelineLayout> pipelineLayout) : m_pipelineLayout(pipelineLayout) {}
+	ComputePipeline(VkDevice device) : m_device(device) {}
 	~ComputePipeline()
 	{
 		destroy();
 	}
 
-	VkResult create(const ShaderPipelineState& shaderStage, VkPipelineCreateFlags flags = 0);
+	VkResult create(VkPipelineLayout layout, const ShaderPipelineState& shaderStage, VkPipelineCreateFlags flags = 0);
 	VkResult destroy();
 
 	inline VkPipeline getHandle() const
@@ -774,14 +801,12 @@ public:
 		return m_handle;
 	}
 
-	std::shared_ptr<PipelineLayout> m_pipelineLayout;
-
 private:
+	VkDevice m_device = VK_NULL_HANDLE;
 	VkPipeline m_handle = VK_NULL_HANDLE;
 	VkComputePipelineCreateInfo m_createInfo { VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO, nullptr };
 
 	VkPipelineShaderStageCreateInfo m_shaderStageCreateInfo;
-	std::shared_ptr<Shader>         m_shader;
 	std::string                           m_shaderEntry;
 	VkSpecializationInfo                  m_specializationInfo;
 	std::vector<VkSpecializationMapEntry> m_specializationMapEntries;

--- a/src/vulkan_graphics_multi_draw.cpp
+++ b/src/vulkan_graphics_multi_draw.cpp
@@ -243,6 +243,7 @@ public:
 		m_bgImageView = nullptr;
 		m_descriptor = nullptr;
 		m_pipeline = nullptr;
+		m_pipelineLayout = nullptr;
 
 		if (m_frameFence != VK_NULL_HANDLE)
 		{
@@ -259,6 +260,7 @@ public:
 	std::unique_ptr<ImageView> m_bgImageView;
 
 	std::unique_ptr<GraphicPipeline> m_pipeline;
+	std::shared_ptr<PipelineLayout> m_pipelineLayout;
 	std::unique_ptr<DescriptorSet> m_descriptor;
 
 	VkFence m_frameFence = VK_NULL_HANDLE;
@@ -378,19 +380,20 @@ int main(int argc, char** argv)
 	mainDescSetLayout->create();
 
 #define MAX_DESCRIPTOR_SET_SIZE 4
-	auto mainDescSetPool = std::make_shared<DescriptorSetPool>(mainDescSetLayout);
-	mainDescSetPool->create(MAX_DESCRIPTOR_SET_SIZE);
+	auto mainDescSetPool = std::make_shared<DescriptorSetPool>(vulkan.device);
+	mainDescSetPool->create(MAX_DESCRIPTOR_SET_SIZE,
+	                        {{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, MAX_DESCRIPTOR_SET_SIZE},
+	                         {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, MAX_DESCRIPTOR_SET_SIZE}});
 
 	auto descriptor = std::make_unique<DescriptorSet>(std::move(mainDescSetPool));
-	descriptor->create();
-	descriptor->setBuffer(0, *transformUniformBuffer);
-	descriptor->setCombinedImageSampler(1, *bgImageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *bgSampler);
+	descriptor->create(*mainDescSetLayout);
+	descriptor->setBuffer(0, 0, *transformUniformBuffer);
+	descriptor->setCombinedImageSampler(1, 0, *bgImageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *bgSampler);
 	descriptor->update();
 
-	std::unordered_map<uint32_t, std::shared_ptr<DescriptorSetLayout>> layoutMap = { {0, mainDescSetLayout} };
+	std::vector<VkDescriptorSetLayout> setLayouts = { mainDescSetLayout->getHandle() };
 	auto pipelineLayout = std::make_shared<PipelineLayout>(vulkan.device);
-	pipelineLayout->create(layoutMap);
-	layoutMap[0] = nullptr;
+	pipelineLayout->create(setLayouts);
 
 	GraphicPipelineState pipelineState;
 	pipelineState.setVertexBinding(0, *vertexBuffer, sizeof(Vertex));
@@ -413,8 +416,8 @@ int main(int argc, char** argv)
 	auto depthImageView = std::make_shared<ImageView>(std::move(depthImage));
 	depthImageView->create(VK_IMAGE_VIEW_TYPE_2D, VK_IMAGE_ASPECT_DEPTH_BIT);
 
-	AttachmentInfo color{ 0, std::move(colorImageView), VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL };
-	AttachmentInfo depth{ 1, std::move(depthImageView), VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL };
+	AttachmentInfo color{ 0, *colorImageView, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL };
+	AttachmentInfo depth{ 1, *depthImageView, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL };
 
 	SubpassInfo subpass{};
 	subpass.addColorAttachment(color, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
@@ -435,13 +438,13 @@ int main(int argc, char** argv)
 	pipelineState.setColorBlendAttachment(color.m_location, colorBlendAttachment);
 
 	auto framebuffer = std::make_shared<FrameBuffer>(vulkan.device);
-	framebuffer->create(*renderpass, {p_benchmark->width, p_benchmark->height});
+	framebuffer->create(*renderpass, {colorImageView, depthImageView}, {p_benchmark->width, p_benchmark->height});
 
 	ShaderPipelineState vertShaderState(VK_SHADER_STAGE_VERTEX_BIT, std::move(vertShader));
 	ShaderPipelineState fragShaderState(VK_SHADER_STAGE_FRAGMENT_BIT, std::move(fragShader));
 
-	auto pipeline = std::make_unique<GraphicPipeline>(std::move(pipelineLayout));
-	pipeline->create({vertShaderState, fragShaderState}, pipelineState, *renderpass);
+	auto pipeline = std::make_unique<GraphicPipeline>(vulkan.device);
+	pipeline->create(pipelineLayout->getHandle(), {vertShaderState, fragShaderState}, pipelineState, *renderpass);
 
 	test_set_name(vulkan, VK_OBJECT_TYPE_BUFFER, (uint64_t)vertexBuffer->getHandle(), "graphics_multi_draw_vertex");
 	test_set_name(vulkan, VK_OBJECT_TYPE_BUFFER, (uint64_t)indexBuffer->getHandle(), "graphics_multi_draw_index");
@@ -454,6 +457,7 @@ int main(int argc, char** argv)
 	p_benchmark->m_bgSampler = std::move(bgSampler);
 	p_benchmark->m_bgImageView = std::move(bgImageView);
 	p_benchmark->m_descriptor = std::move(descriptor);
+	p_benchmark->m_pipelineLayout = std::move(pipelineLayout);
 	p_benchmark->m_pipeline = std::move(pipeline);
 	p_benchmark->m_renderPass = std::move(renderpass);
 	p_benchmark->m_framebuffer = std::move(framebuffer);
@@ -665,7 +669,7 @@ static void render(const vulkan_setup_t& vulkan)
 		vkCmdBindIndexBuffer(defaultCmd, p_benchmark->m_indexBuffer->getHandle(), 0, VK_INDEX_TYPE_UINT16);
 
 		VkDescriptorSet descriptor = p_benchmark->m_descriptor->getHandle();
-		vkCmdBindDescriptorSets(defaultCmd, VK_PIPELINE_BIND_POINT_GRAPHICS, p_benchmark->m_pipeline->m_pipelineLayout->getHandle(), 0, 1, &descriptor, 0, nullptr);
+		vkCmdBindDescriptorSets(defaultCmd, VK_PIPELINE_BIND_POINT_GRAPHICS, p_benchmark->m_pipelineLayout->getHandle(), 0, 1, &descriptor, 0, nullptr);
 
 		VkViewport viewport{};
 		viewport.x = 0.0f;

--- a/src/vulkan_vkquake2.cpp
+++ b/src/vulkan_vkquake2.cpp
@@ -232,8 +232,7 @@ public:
 		sampler = nullptr;
 		samplerLayout = nullptr;
 		uboLayout = nullptr;
-		samplerPool = nullptr;
-		uboPool = nullptr;
+		descriptorPool = nullptr;
 
 		ds_base = nullptr;
 		ds_lightmap = nullptr;
@@ -320,8 +319,7 @@ public:
 	std::unique_ptr<Sampler> sampler;
 	std::shared_ptr<DescriptorSetLayout> samplerLayout;
 	std::shared_ptr<DescriptorSetLayout> uboLayout;
-	std::shared_ptr<DescriptorSetPool> samplerPool;
-	std::shared_ptr<DescriptorSetPool> uboPool;
+	std::shared_ptr<DescriptorSetPool> descriptorPool;
 
 	std::unique_ptr<DescriptorSet> ds_base;
 	std::unique_ptr<DescriptorSet> ds_lightmap;
@@ -683,13 +681,13 @@ int main(int argc, char** argv)
 
 	// Render passes
 	{
-		AttachmentInfo worldColor(0, ctx->worldColor.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+		AttachmentInfo worldColor(0, *ctx->worldColor.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 		worldColor.m_description.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 		worldColor.m_description.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 		worldColor.m_description.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 		worldColor.m_clear.color = { {0.1f, 0.1f, 0.2f, 1.0f} };
 
-		AttachmentInfo worldDepth(1, ctx->worldDepthView, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+		AttachmentInfo worldDepth(1, *ctx->worldDepthView, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
 		worldDepth.m_description.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 		worldDepth.m_description.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		worldDepth.m_description.initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
@@ -702,11 +700,11 @@ int main(int argc, char** argv)
 		ctx->worldPass = std::make_shared<RenderPass>(vulkan.device);
 		ctx->worldPass->create({worldColor, worldDepth}, {subpass});
 		ctx->worldFB = std::make_shared<FrameBuffer>(vulkan.device);
-		ctx->worldFB->create(*ctx->worldPass, {ctx->width, ctx->height});
+		ctx->worldFB->create(*ctx->worldPass, {ctx->worldColor.view, ctx->worldDepthView}, {ctx->width, ctx->height});
 	}
 
 	{
-		AttachmentInfo warpColor(0, ctx->warpColor.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+		AttachmentInfo warpColor(0, *ctx->warpColor.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 		warpColor.m_description.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 		warpColor.m_description.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 		warpColor.m_description.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -718,11 +716,11 @@ int main(int argc, char** argv)
 		ctx->warpPass = std::make_shared<RenderPass>(vulkan.device);
 		ctx->warpPass->create({warpColor}, {subpass});
 		ctx->warpFB = std::make_shared<FrameBuffer>(vulkan.device);
-		ctx->warpFB->create(*ctx->warpPass, {ctx->width, ctx->height});
+		ctx->warpFB->create(*ctx->warpPass, {ctx->warpColor.view}, {ctx->width, ctx->height});
 	}
 
 	{
-		AttachmentInfo uiColor(0, ctx->uiColor.view, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+		AttachmentInfo uiColor(0, *ctx->uiColor.view, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 		uiColor.m_description.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 		uiColor.m_description.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 		uiColor.m_description.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -734,7 +732,7 @@ int main(int argc, char** argv)
 		ctx->uiPass = std::make_shared<RenderPass>(vulkan.device);
 		ctx->uiPass->create({uiColor}, {subpass});
 		ctx->uiFB = std::make_shared<FrameBuffer>(vulkan.device);
-		ctx->uiFB->create(*ctx->uiPass, {ctx->width, ctx->height});
+		ctx->uiFB->create(*ctx->uiPass, {ctx->uiColor.view}, {ctx->width, ctx->height});
 
 		ctx->m_renderPass = ctx->uiPass;
 		ctx->m_framebuffer = ctx->uiFB;
@@ -754,40 +752,40 @@ int main(int argc, char** argv)
 	ctx->uboLayout->insertBinding(0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_SHADER_STAGE_ALL_GRAPHICS);
 	ctx->uboLayout->create();
 
-	ctx->samplerPool = std::make_shared<DescriptorSetPool>(ctx->samplerLayout);
-	ctx->samplerPool->create(16);
-	ctx->uboPool = std::make_shared<DescriptorSetPool>(ctx->uboLayout);
-	ctx->uboPool->create(16);
+	ctx->descriptorPool = std::make_shared<DescriptorSetPool>(vulkan.device);
+	ctx->descriptorPool->create(16,
+	                           {{VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 16},
+	                            {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 16}});
 
 	// Descriptor sets for textures
-	ctx->ds_base = std::make_unique<DescriptorSet>(ctx->samplerPool);
-	ctx->ds_base->create();
-	ctx->ds_base->setCombinedImageSampler(0, *ctx->baseTex.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *ctx->sampler);
+	ctx->ds_base = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_base->create(*ctx->samplerLayout);
+	ctx->ds_base->setCombinedImageSampler(0, 0, *ctx->baseTex.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *ctx->sampler);
 	ctx->ds_base->update();
 
-	ctx->ds_lightmap = std::make_unique<DescriptorSet>(ctx->samplerPool);
-	ctx->ds_lightmap->create();
-	ctx->ds_lightmap->setCombinedImageSampler(0, *ctx->lightmapTex.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *ctx->sampler);
+	ctx->ds_lightmap = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_lightmap->create(*ctx->samplerLayout);
+	ctx->ds_lightmap->setCombinedImageSampler(0, 0, *ctx->lightmapTex.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *ctx->sampler);
 	ctx->ds_lightmap->update();
 
-	ctx->ds_sky = std::make_unique<DescriptorSet>(ctx->samplerPool);
-	ctx->ds_sky->create();
-	ctx->ds_sky->setCombinedImageSampler(0, *ctx->skyTex.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *ctx->sampler);
+	ctx->ds_sky = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_sky->create(*ctx->samplerLayout);
+	ctx->ds_sky->setCombinedImageSampler(0, 0, *ctx->skyTex.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *ctx->sampler);
 	ctx->ds_sky->update();
 
-	ctx->ds_ui = std::make_unique<DescriptorSet>(ctx->samplerPool);
-	ctx->ds_ui->create();
-	ctx->ds_ui->setCombinedImageSampler(0, *ctx->uiTex.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *ctx->sampler);
+	ctx->ds_ui = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_ui->create(*ctx->samplerLayout);
+	ctx->ds_ui->setCombinedImageSampler(0, 0, *ctx->uiTex.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *ctx->sampler);
 	ctx->ds_ui->update();
 
-	ctx->ds_worldColor = std::make_unique<DescriptorSet>(ctx->samplerPool);
-	ctx->ds_worldColor->create();
-	ctx->ds_worldColor->setCombinedImageSampler(0, *ctx->worldColor.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *ctx->sampler);
+	ctx->ds_worldColor = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_worldColor->create(*ctx->samplerLayout);
+	ctx->ds_worldColor->setCombinedImageSampler(0, 0, *ctx->worldColor.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *ctx->sampler);
 	ctx->ds_worldColor->update();
 
-	ctx->ds_warpColor = std::make_unique<DescriptorSet>(ctx->samplerPool);
-	ctx->ds_warpColor->create();
-	ctx->ds_warpColor->setCombinedImageSampler(0, *ctx->warpColor.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *ctx->sampler);
+	ctx->ds_warpColor = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_warpColor->create(*ctx->samplerLayout);
+	ctx->ds_warpColor->setCombinedImageSampler(0, 0, *ctx->warpColor.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, *ctx->sampler);
 	ctx->ds_warpColor->update();
 
 	// Vertex buffers
@@ -944,49 +942,49 @@ int main(int argc, char** argv)
 	ctx->ubo_colorquad->map();
 
 	// Descriptor sets for UBOs
-	ctx->ds_ubo_world = std::make_unique<DescriptorSet>(ctx->uboPool);
-	ctx->ds_ubo_world->create();
-	ctx->ds_ubo_world->setBuffer(0, *ctx->ubo_world);
+	ctx->ds_ubo_world = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_ubo_world->create(*ctx->uboLayout);
+	ctx->ds_ubo_world->setBuffer(0, 0, *ctx->ubo_world);
 	ctx->ds_ubo_world->update();
 
-	ctx->ds_ubo_water = std::make_unique<DescriptorSet>(ctx->uboPool);
-	ctx->ds_ubo_water->create();
-	ctx->ds_ubo_water->setBuffer(0, *ctx->ubo_water);
+	ctx->ds_ubo_water = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_ubo_water->create(*ctx->uboLayout);
+	ctx->ds_ubo_water->setBuffer(0, 0, *ctx->ubo_water);
 	ctx->ds_ubo_water->update();
 
-	ctx->ds_ubo_model = std::make_unique<DescriptorSet>(ctx->uboPool);
-	ctx->ds_ubo_model->create();
-	ctx->ds_ubo_model->setBuffer(0, *ctx->ubo_model);
+	ctx->ds_ubo_model = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_ubo_model->create(*ctx->uboLayout);
+	ctx->ds_ubo_model->setBuffer(0, 0, *ctx->ubo_model);
 	ctx->ds_ubo_model->update();
 
-	ctx->ds_ubo_sprite = std::make_unique<DescriptorSet>(ctx->uboPool);
-	ctx->ds_ubo_sprite->create();
-	ctx->ds_ubo_sprite->setBuffer(0, *ctx->ubo_sprite);
+	ctx->ds_ubo_sprite = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_ubo_sprite->create(*ctx->uboLayout);
+	ctx->ds_ubo_sprite->setBuffer(0, 0, *ctx->ubo_sprite);
 	ctx->ds_ubo_sprite->update();
 
-	ctx->ds_ubo_sky = std::make_unique<DescriptorSet>(ctx->uboPool);
-	ctx->ds_ubo_sky->create();
-	ctx->ds_ubo_sky->setBuffer(0, *ctx->ubo_sky);
+	ctx->ds_ubo_sky = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_ubo_sky->create(*ctx->uboLayout);
+	ctx->ds_ubo_sky->setBuffer(0, 0, *ctx->ubo_sky);
 	ctx->ds_ubo_sky->update();
 
-	ctx->ds_ubo_basic = std::make_unique<DescriptorSet>(ctx->uboPool);
-	ctx->ds_ubo_basic->create();
-	ctx->ds_ubo_basic->setBuffer(0, *ctx->ubo_basic);
+	ctx->ds_ubo_basic = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_ubo_basic->create(*ctx->uboLayout);
+	ctx->ds_ubo_basic->setBuffer(0, 0, *ctx->ubo_basic);
 	ctx->ds_ubo_basic->update();
 
-	ctx->ds_ubo_beam = std::make_unique<DescriptorSet>(ctx->uboPool);
-	ctx->ds_ubo_beam->create();
-	ctx->ds_ubo_beam->setBuffer(0, *ctx->ubo_beam);
+	ctx->ds_ubo_beam = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_ubo_beam->create(*ctx->uboLayout);
+	ctx->ds_ubo_beam->setBuffer(0, 0, *ctx->ubo_beam);
 	ctx->ds_ubo_beam->update();
 
-	ctx->ds_ubo_dlight = std::make_unique<DescriptorSet>(ctx->uboPool);
-	ctx->ds_ubo_dlight->create();
-	ctx->ds_ubo_dlight->setBuffer(0, *ctx->ubo_dlight);
+	ctx->ds_ubo_dlight = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_ubo_dlight->create(*ctx->uboLayout);
+	ctx->ds_ubo_dlight->setBuffer(0, 0, *ctx->ubo_dlight);
 	ctx->ds_ubo_dlight->update();
 
-	ctx->ds_ubo_colorquad = std::make_unique<DescriptorSet>(ctx->uboPool);
-	ctx->ds_ubo_colorquad->create();
-	ctx->ds_ubo_colorquad->setBuffer(0, *ctx->ubo_colorquad);
+	ctx->ds_ubo_colorquad = std::make_unique<DescriptorSet>(ctx->descriptorPool);
+	ctx->ds_ubo_colorquad->create(*ctx->uboLayout);
+	ctx->ds_ubo_colorquad->setBuffer(0, 0, *ctx->ubo_colorquad);
 	ctx->ds_ubo_colorquad->update();
 
 	// Fill UBO data
@@ -1066,25 +1064,25 @@ int main(int argc, char** argv)
 		pc_frag.offset = 0;
 		pc_frag.size = sizeof(float) * 4;
 
-		std::unordered_map<uint32_t, std::shared_ptr<DescriptorSetLayout>> sampler_ubo = {{0, ctx->samplerLayout}, {1, ctx->uboLayout}};
+		std::vector<VkDescriptorSetLayout> sampler_ubo = {ctx->samplerLayout->getHandle(), ctx->uboLayout->getHandle()};
 		ctx->layout_sampler_ubo_pc = std::make_shared<PipelineLayout>(vulkan.device);
 		ctx->layout_sampler_ubo_pc->create(sampler_ubo, {pc_mat});
 
 		ctx->layout_sampler_ubo = std::make_shared<PipelineLayout>(vulkan.device);
 		ctx->layout_sampler_ubo->create(sampler_ubo);
 
-		std::unordered_map<uint32_t, std::shared_ptr<DescriptorSetLayout>> sampler_ubo_lmap = {{0, ctx->samplerLayout}, {1, ctx->uboLayout}, {2, ctx->samplerLayout}};
+		std::vector<VkDescriptorSetLayout> sampler_ubo_lmap = {ctx->samplerLayout->getHandle(), ctx->uboLayout->getHandle(), ctx->samplerLayout->getHandle()};
 		ctx->layout_sampler_ubo_lmap_pc = std::make_shared<PipelineLayout>(vulkan.device);
 		ctx->layout_sampler_ubo_lmap_pc->create(sampler_ubo_lmap, {pc_mat});
 
-		std::unordered_map<uint32_t, std::shared_ptr<DescriptorSetLayout>> sampler_only = {{0, ctx->samplerLayout}};
+		std::vector<VkDescriptorSetLayout> sampler_only = {ctx->samplerLayout->getHandle()};
 		ctx->layout_sampler_pc = std::make_shared<PipelineLayout>(vulkan.device);
 		ctx->layout_sampler_pc->create(sampler_only, {pc_mat});
 
 		ctx->layout_sampler_frag_pc = std::make_shared<PipelineLayout>(vulkan.device);
 		ctx->layout_sampler_frag_pc->create(sampler_only, {pc_frag});
 
-		std::unordered_map<uint32_t, std::shared_ptr<DescriptorSetLayout>> ubo_only = {{0, ctx->uboLayout}};
+		std::vector<VkDescriptorSetLayout> ubo_only = {ctx->uboLayout->getHandle()};
 		ctx->layout_ubo_pc = std::make_shared<PipelineLayout>(vulkan.device);
 		ctx->layout_ubo_pc->create(ubo_only, {pc_mat});
 
@@ -1155,8 +1153,8 @@ int main(int argc, char** argv)
 
 		ShaderPipelineState lmapVS(VK_SHADER_STAGE_VERTEX_BIT, sh_lmap_vert);
 		ShaderPipelineState lmapFS(VK_SHADER_STAGE_FRAGMENT_BIT, sh_lmap_frag);
-		ctx->pipe_world_lmap = std::make_unique<GraphicPipeline>(ctx->layout_sampler_ubo_lmap_pc);
-		ctx->pipe_world_lmap->create({lmapVS, lmapFS}, lmapState, *ctx->worldPass);
+		ctx->pipe_world_lmap = std::make_unique<GraphicPipeline>(vulkan.device);
+		ctx->pipe_world_lmap->create(ctx->layout_sampler_ubo_lmap_pc->getHandle(), {lmapVS, lmapFS}, lmapState, *ctx->worldPass);
 	}
 
 	{
@@ -1172,8 +1170,8 @@ int main(int argc, char** argv)
 
 		ShaderPipelineState waterVS(VK_SHADER_STAGE_VERTEX_BIT, sh_warp_vert);
 		ShaderPipelineState waterFS(VK_SHADER_STAGE_FRAGMENT_BIT, sh_basic_frag);
-		ctx->pipe_water = std::make_unique<GraphicPipeline>(ctx->layout_sampler_ubo_pc);
-		ctx->pipe_water->create({waterVS, waterFS}, waterState, *ctx->worldPass);
+		ctx->pipe_water = std::make_unique<GraphicPipeline>(vulkan.device);
+		ctx->pipe_water->create(ctx->layout_sampler_ubo_pc->getHandle(), {waterVS, waterFS}, waterState, *ctx->worldPass);
 	}
 
 	{
@@ -1189,8 +1187,8 @@ int main(int argc, char** argv)
 
 		ShaderPipelineState modelVS(VK_SHADER_STAGE_VERTEX_BIT, sh_model_vert);
 		ShaderPipelineState modelFS(VK_SHADER_STAGE_FRAGMENT_BIT, sh_model_frag);
-		ctx->pipe_model = std::make_unique<GraphicPipeline>(ctx->layout_sampler_ubo_pc);
-		ctx->pipe_model->create({modelVS, modelFS}, modelState, *ctx->worldPass);
+		ctx->pipe_model = std::make_unique<GraphicPipeline>(vulkan.device);
+		ctx->pipe_model->create(ctx->layout_sampler_ubo_pc->getHandle(), {modelVS, modelFS}, modelState, *ctx->worldPass);
 	}
 
 	{
@@ -1206,8 +1204,8 @@ int main(int argc, char** argv)
 
 		ShaderPipelineState spriteVS(VK_SHADER_STAGE_VERTEX_BIT, sh_sprite_vert);
 		ShaderPipelineState spriteFS(VK_SHADER_STAGE_FRAGMENT_BIT, sh_basic_frag);
-		ctx->pipe_sprite = std::make_unique<GraphicPipeline>(ctx->layout_sampler_ubo_pc);
-		ctx->pipe_sprite->create({spriteVS, spriteFS}, spriteState, *ctx->worldPass);
+		ctx->pipe_sprite = std::make_unique<GraphicPipeline>(vulkan.device);
+		ctx->pipe_sprite->create(ctx->layout_sampler_ubo_pc->getHandle(), {spriteVS, spriteFS}, spriteState, *ctx->worldPass);
 	}
 
 	{
@@ -1224,8 +1222,8 @@ int main(int argc, char** argv)
 
 		ShaderPipelineState particleVS(VK_SHADER_STAGE_VERTEX_BIT, sh_particle_vert);
 		ShaderPipelineState particleFS(VK_SHADER_STAGE_FRAGMENT_BIT, sh_basic_frag);
-		ctx->pipe_particle = std::make_unique<GraphicPipeline>(ctx->layout_sampler_pc);
-		ctx->pipe_particle->create({particleVS, particleFS}, particleState, *ctx->worldPass);
+		ctx->pipe_particle = std::make_unique<GraphicPipeline>(vulkan.device);
+		ctx->pipe_particle->create(ctx->layout_sampler_pc->getHandle(), {particleVS, particleFS}, particleState, *ctx->worldPass);
 	}
 
 	{
@@ -1242,8 +1240,8 @@ int main(int argc, char** argv)
 
 		ShaderPipelineState skyVS(VK_SHADER_STAGE_VERTEX_BIT, sh_sky_vert);
 		ShaderPipelineState skyFS(VK_SHADER_STAGE_FRAGMENT_BIT, sh_basic_frag);
-		ctx->pipe_sky = std::make_unique<GraphicPipeline>(ctx->layout_sampler_ubo_pc);
-		ctx->pipe_sky->create({skyVS, skyFS}, skyState, *ctx->worldPass);
+		ctx->pipe_sky = std::make_unique<GraphicPipeline>(vulkan.device);
+		ctx->pipe_sky->create(ctx->layout_sampler_ubo_pc->getHandle(), {skyVS, skyFS}, skyState, *ctx->worldPass);
 	}
 
 	{
@@ -1259,8 +1257,8 @@ int main(int argc, char** argv)
 
 		ShaderPipelineState beamVS(VK_SHADER_STAGE_VERTEX_BIT, sh_beam_vert);
 		ShaderPipelineState beamFS(VK_SHADER_STAGE_FRAGMENT_BIT, sh_basic_color_frag);
-		ctx->pipe_beam = std::make_unique<GraphicPipeline>(ctx->layout_ubo_pc);
-		ctx->pipe_beam->create({beamVS, beamFS}, beamState, *ctx->worldPass);
+		ctx->pipe_beam = std::make_unique<GraphicPipeline>(vulkan.device);
+		ctx->pipe_beam->create(ctx->layout_ubo_pc->getHandle(), {beamVS, beamFS}, beamState, *ctx->worldPass);
 	}
 
 	{
@@ -1276,8 +1274,8 @@ int main(int argc, char** argv)
 
 		ShaderPipelineState dlightVS(VK_SHADER_STAGE_VERTEX_BIT, sh_dlight_vert);
 		ShaderPipelineState dlightFS(VK_SHADER_STAGE_FRAGMENT_BIT, sh_basic_color_frag);
-		ctx->pipe_dlight = std::make_unique<GraphicPipeline>(ctx->layout_ubo);
-		ctx->pipe_dlight->create({dlightVS, dlightFS}, dlightState, *ctx->worldPass);
+		ctx->pipe_dlight = std::make_unique<GraphicPipeline>(vulkan.device);
+		ctx->pipe_dlight->create(ctx->layout_ubo->getHandle(), {dlightVS, dlightFS}, dlightState, *ctx->worldPass);
 	}
 
 	{
@@ -1291,8 +1289,8 @@ int main(int argc, char** argv)
 
 		ShaderPipelineState warpVS(VK_SHADER_STAGE_VERTEX_BIT, sh_worldwarp_vert);
 		ShaderPipelineState warpFS(VK_SHADER_STAGE_FRAGMENT_BIT, sh_worldwarp_frag);
-		ctx->pipe_worldwarp = std::make_unique<GraphicPipeline>(ctx->layout_sampler_frag_pc);
-		ctx->pipe_worldwarp->create({warpVS, warpFS}, warpState, *ctx->warpPass);
+		ctx->pipe_worldwarp = std::make_unique<GraphicPipeline>(vulkan.device);
+		ctx->pipe_worldwarp->create(ctx->layout_sampler_frag_pc->getHandle(), {warpVS, warpFS}, warpState, *ctx->warpPass);
 	}
 
 	{
@@ -1306,8 +1304,8 @@ int main(int argc, char** argv)
 
 		ShaderPipelineState postVS(VK_SHADER_STAGE_VERTEX_BIT, sh_post_vert);
 		ShaderPipelineState postFS(VK_SHADER_STAGE_FRAGMENT_BIT, sh_post_frag);
-		ctx->pipe_postprocess = std::make_unique<GraphicPipeline>(ctx->layout_sampler_frag_pc);
-		ctx->pipe_postprocess->create({postVS, postFS}, postState, *ctx->uiPass);
+		ctx->pipe_postprocess = std::make_unique<GraphicPipeline>(vulkan.device);
+		ctx->pipe_postprocess->create(ctx->layout_sampler_frag_pc->getHandle(), {postVS, postFS}, postState, *ctx->uiPass);
 	}
 
 	{
@@ -1324,8 +1322,8 @@ int main(int argc, char** argv)
 
 		ShaderPipelineState basicVS(VK_SHADER_STAGE_VERTEX_BIT, sh_basic_vert);
 		ShaderPipelineState basicFS(VK_SHADER_STAGE_FRAGMENT_BIT, sh_basic_frag);
-		ctx->pipe_basic = std::make_unique<GraphicPipeline>(ctx->layout_sampler_ubo);
-		ctx->pipe_basic->create({basicVS, basicFS}, basicState, *ctx->uiPass);
+		ctx->pipe_basic = std::make_unique<GraphicPipeline>(vulkan.device);
+		ctx->pipe_basic->create(ctx->layout_sampler_ubo->getHandle(), {basicVS, basicFS}, basicState, *ctx->uiPass);
 	}
 
 	{
@@ -1341,8 +1339,8 @@ int main(int argc, char** argv)
 
 		ShaderPipelineState colorVS(VK_SHADER_STAGE_VERTEX_BIT, sh_basic_color_vert);
 		ShaderPipelineState colorFS(VK_SHADER_STAGE_FRAGMENT_BIT, sh_basic_color_frag);
-		ctx->pipe_colorquad = std::make_unique<GraphicPipeline>(ctx->layout_ubo);
-		ctx->pipe_colorquad->create({colorVS, colorFS}, colorState, *ctx->uiPass);
+		ctx->pipe_colorquad = std::make_unique<GraphicPipeline>(vulkan.device);
+		ctx->pipe_colorquad->create(ctx->layout_ubo->getHandle(), {colorVS, colorFS}, colorState, *ctx->uiPass);
 	}
 
 	// Release local shader refs (pipelines hold the shared_ptrs).


### PR DESCRIPTION
…helpers

Reduce unnecessary std::shared_ptr ownership across vulkan_graphics_common and align wrapper ownership with actual Vulkan lifetime requirements.

Main changes:
  - remove DescriptorSetLayout ownership from PipelineLayout and DescriptorSetPool
  - remove PipelineLayout / Shader ownership fromComputePipeline and GraphicPipeline
  - change ShaderPipelineState shader ownership to private and scoped to stage lifetime
  - rework DescriptorSet creation/update to cache layout metadata locally
  - add null-descriptor support and sparse descriptor-array support in DescriptorSet
  - optimize DescriptorSet::update() by merging adjacent array elements and submitting all writes in a single update call
  - move attachment ImageView ownership from AttachmentInfo/RenderPass to FrameBuffer
  - change m_device to private

Caller/test updates:
  - migrate affected Vulkan tests and demos to the new non-owning APIs

This keeps shared_ptr only where there is a real downstream lifetime dependency, and removes wrapper-side over-ownership used only for convenience.