### PR TITLE
fix Vulkan validation errors in graphics test cleanup

### DIFF
--- a/src/vulkan_graphics_1.cpp
+++ b/src/vulkan_graphics_1.cpp
@@ -288,10 +288,9 @@ int main(int argc, char** argv)
 	//continue: graphicPipeline state
 	pipelineState.setColorBlendAttachment(color.m_location, colorBlendAttachment);
 
-
 	/********************************** framebuffer *********************************/
 	auto framebuffer = std::make_shared<FrameBuffer>(vulkan.device);
-	framebuffer->create(*renderpass, {colorImageView, depthImageView}, {p_benchmark->width, p_benchmark->height});
+	framebuffer->create(*renderpass, {std::move(colorImageView), std::move(depthImageView)}, {p_benchmark->width, p_benchmark->height});
 
 	/*************************** pipeline shader stage ******************************/
 	ShaderPipelineState vertShaderState(VK_SHADER_STAGE_VERTEX_BIT, std::move(vertShader));

--- a/src/vulkan_graphics_common.cpp
+++ b/src/vulkan_graphics_common.cpp
@@ -451,12 +451,6 @@ VkResult CommandBufferPool::destroy()
 	return result;
 }
 
-CommandBuffer::CommandBuffer(std::shared_ptr<CommandBufferPool> commandBufferPool)
-	:m_pCommandBufferPool(commandBufferPool)
-{
-	m_device = commandBufferPool->getDevice();
-}
-
 VkResult CommandBuffer::create(VkCommandBufferLevel commandBufferLevel)
 {
 	m_createInfo.commandPool = m_pCommandBufferPool->getHandle();;
@@ -729,14 +723,14 @@ VkResult RenderPass::destroy()
 	return result;
 }
 
-VkResult FrameBuffer::create(const RenderPass& renderPass, const std::vector<std::shared_ptr<ImageView>>& attachments,
+VkResult FrameBuffer::create(const RenderPass& renderPass, std::vector<std::shared_ptr<ImageView>> attachments,
                              VkExtent2D extent, uint32_t layers /*=1*/ )
 {
 	const auto& attachmentDescriptions = renderPass.getAttachmentDescriptions();
 	assert(attachments.size() == attachmentDescriptions.size());
-	m_attachmentImageViews = attachments;
-	m_attachments.resize(attachments.size());
-	for (size_t i = 0; i < attachments.size(); ++i)
+	m_attachmentImageViews = std::move(attachments);
+	m_attachments.resize(m_attachmentImageViews.size());
+	for (size_t i = 0; i < m_attachmentImageViews.size(); ++i)
 	{
 		assert(m_attachmentImageViews[i]);
 		assert(m_attachmentImageViews[i]->m_pImage);
@@ -777,7 +771,7 @@ VkResult FrameBuffer::destroy()
 }
 
 ShaderPipelineState::ShaderPipelineState(VkShaderStageFlagBits shaderStage, std::shared_ptr<Shader>shader, const std::string& entry /*="main"*/)
-	: m_pShader(shader)
+	: m_pShader(std::move(shader))
 	, m_entry(entry)
 {
 	m_createInfo.flags = 0;
@@ -1055,9 +1049,9 @@ void DescriptorSetLayout::insertNext<VkMutableDescriptorTypeCreateInfoEXT>(const
 	m_createInfoNexts.push_back((VkBaseInStructure*)pInfo);
 }
 
-VkResult DescriptorSetPool::create(uint32_t maxSets, const std::vector<VkDescriptorPoolSize>& poolSizes, VkDescriptorPoolCreateFlags flags /*=0*/)
+VkResult DescriptorSetPool::create(uint32_t maxSets, std::vector<VkDescriptorPoolSize> poolSizes, VkDescriptorPoolCreateFlags flags /*=0*/)
 {
-	m_poolSizes = { poolSizes.begin(), poolSizes.end() };
+	m_poolSizes = std::move(poolSizes);
 	m_createInfo.flags = flags;
 	m_createInfo.poolSizeCount = static_cast<uint32_t>(m_poolSizes.size());
 	m_createInfo.pPoolSizes = m_poolSizes.data();
@@ -1354,15 +1348,15 @@ VkResult DescriptorSet::destroy()
 	return result;
 }
 
-VkResult PipelineLayout::create(const std::vector<VkDescriptorSetLayout>& setLayouts, const std::vector<VkPushConstantRange>& pushConstantRanges/*={}*/)
+VkResult PipelineLayout::create(std::vector<VkDescriptorSetLayout> setLayouts, std::vector<VkPushConstantRange> pushConstantRanges/*={}*/)
 {
-	m_descriptorSetLayouts = {setLayouts.begin(), setLayouts.end()};
-	m_pushConstantRanges   = {pushConstantRanges.begin(), pushConstantRanges.end()};
+	m_descriptorSetLayouts = std::move(setLayouts);
+	m_pushConstantRanges   = std::move(pushConstantRanges);
 	return create();
 }
-VkResult PipelineLayout::create(const std::vector<VkPushConstantRange>& pushConstantRanges)
+VkResult PipelineLayout::create(std::vector<VkPushConstantRange> pushConstantRanges)
 {
-	m_pushConstantRanges = {pushConstantRanges.begin(), pushConstantRanges.end()};
+	m_pushConstantRanges = std::move(pushConstantRanges);
 	return create();
 }
 

--- a/src/vulkan_graphics_common.h
+++ b/src/vulkan_graphics_common.h
@@ -80,7 +80,7 @@ private:
 class TexelBufferView
 {
 public:
-	TexelBufferView(std::shared_ptr<Buffer> buffer) : m_pBuffer(buffer) {}
+	TexelBufferView(std::shared_ptr<Buffer> buffer) : m_pBuffer(std::move(buffer)) {}
 	~TexelBufferView() {
 		destroy();
 	}
@@ -143,7 +143,7 @@ private:
 class ImageView
 {
 public:
-	ImageView(std::shared_ptr<Image> image) : m_pImage(image) {}
+	ImageView(std::shared_ptr<Image> image) : m_pImage(std::move(image)) {}
 	~ImageView() {
 		destroy();
 	}
@@ -216,7 +216,8 @@ private:
 class CommandBuffer
 {
 public:
-	CommandBuffer(std::shared_ptr<CommandBufferPool> commandBufferPool);
+	CommandBuffer(std::shared_ptr<CommandBufferPool> commandBufferPool)
+		: m_pCommandBufferPool(std::move(commandBufferPool)), m_device(m_pCommandBufferPool->getDevice()) { };
 	~CommandBuffer() {
 		destroy();
 	}
@@ -378,7 +379,7 @@ public:
 		destroy();
 	}
 
-	VkResult create(uint32_t maxSets, const std::vector<VkDescriptorPoolSize>& poolSizes, VkDescriptorPoolCreateFlags flags = 0);
+	VkResult create(uint32_t maxSets, std::vector<VkDescriptorPoolSize> poolSizes, VkDescriptorPoolCreateFlags flags = 0);
 	VkResult create(const DescriptorPoolCreateFuncType& createFunc);
 	VkResult destroy();
 
@@ -426,7 +427,7 @@ class DescriptorSet
 {
 public:
 	DescriptorSet(std::shared_ptr<DescriptorSetPool> pool)
-		: m_pDescriptorSetPool(pool), m_device(pool->getDevice()) { };
+		: m_pDescriptorSetPool(std::move(pool)), m_device(m_pDescriptorSetPool->getDevice()) { };
 	~DescriptorSet() {
 		destroy();
 	}
@@ -481,8 +482,8 @@ public:
 		destroy();
 	}
 
-	VkResult create(const std::vector<VkDescriptorSetLayout>& setLayouts, const std::vector<VkPushConstantRange>& pushConstantRanges = {});
-	VkResult create(const std::vector<VkPushConstantRange>& pushConstantRanges);
+	VkResult create(std::vector<VkDescriptorSetLayout> setLayouts, std::vector<VkPushConstantRange> pushConstantRanges = {});
+	VkResult create(std::vector<VkPushConstantRange> pushConstantRanges);
 	VkResult destroy();
 
 	inline VkPipelineLayout getHandle() const {
@@ -634,7 +635,7 @@ public:
 		destroy();
 	}
 
-	VkResult create(const RenderPass& renderPass, const std::vector<std::shared_ptr<ImageView>>& attachments,
+	VkResult create(const RenderPass& renderPass, std::vector<std::shared_ptr<ImageView>> attachments,
 	                VkExtent2D extent, uint32_t layers = 1);
 	VkResult destroy();
 

--- a/src/vulkan_graphics_multi_draw.cpp
+++ b/src/vulkan_graphics_multi_draw.cpp
@@ -438,7 +438,7 @@ int main(int argc, char** argv)
 	pipelineState.setColorBlendAttachment(color.m_location, colorBlendAttachment);
 
 	auto framebuffer = std::make_shared<FrameBuffer>(vulkan.device);
-	framebuffer->create(*renderpass, {colorImageView, depthImageView}, {p_benchmark->width, p_benchmark->height});
+	framebuffer->create(*renderpass, {std::move(colorImageView), std::move(depthImageView)}, {p_benchmark->width, p_benchmark->height});
 
 	ShaderPipelineState vertShaderState(VK_SHADER_STAGE_VERTEX_BIT, std::move(vertShader));
 	ShaderPipelineState fragShaderState(VK_SHADER_STAGE_FRAGMENT_BIT, std::move(fragShader));


### PR DESCRIPTION
The root cause was local shared_ptr owners in test callers outliving the framebuffer/context and therefore surviving past device destruction.
